### PR TITLE
OPT Improves design and tests for edit captured reference form

### DIFF
--- a/src/cljs/kti_web/core.cljs
+++ b/src/cljs/kti_web/core.cljs
@@ -10,7 +10,7 @@
    [kti-web.local-storage :as local-storage]))
 
 (declare capture-form captured-refs-table delete-captured-ref-form token-input-inner
-         host-input-inner edit-captured-ref-form captured-ref-form select-captured-ref)
+         host-input-inner edit-captured-ref-comp captured-ref-inputs select-captured-ref)
 
 ;; -------------------------
 ;; State & Globals
@@ -97,7 +97,7 @@
      [:div
       [:h2 "Captured References"]
       [capture-form {:post! post-captured-reference!}]
-      [edit-captured-ref-form {:hput! put-captured-reference!}]
+      [edit-captured-ref-comp {:hput! put-captured-reference!}]
       [delete-captured-ref-form {:delete! delete-captured-reference!}]
       [captured-refs-table {:get! get-captured-references!}]]]))
 
@@ -161,7 +161,9 @@
                       :on-change #(swap! state assoc :value %))
                capture-form-inner))))
 
-(defn edit-captured-ref-form [{:keys [hput!]}]
+(declare edit-captured-ref-comp--form)
+
+(defn edit-captured-ref-comp [{:keys [hput!]}]
   "A form to edit a captured reference."
   (let [selected-id-value (r/atom nil)
         selected-cap-ref (r/atom nil)
@@ -180,14 +182,22 @@
          :on-selection #(do (reset! selected-cap-ref %) (reset! editted-cap-ref %))
          :id-value @selected-id-value
          :on-id-change #(reset! selected-id-value %)}]
-       [:div {:hidden (nil? @editted-cap-ref)}
-        [captured-ref-form {:value @editted-cap-ref
-                            :on-change #(reset! editted-cap-ref %)}]
-        [:form {:on-submit (call-prevent-default handle-submit)}
-         [:button {:type "Submit"} "Submit"]]
-        [:div @status]]])))
+       [edit-captured-ref-comp--form
+        {:editted-cap-ref @editted-cap-ref
+         :on-editted-cap-ref-change #(reset! editted-cap-ref %)
+         :on-submit (call-prevent-default handle-submit)
+         :status @status}]])))
 
-(defn captured-ref-form [{:keys [value on-change]}]
+(defn edit-captured-ref-comp--form
+  [{:keys [editted-cap-ref on-editted-cap-ref-change on-submit status]}]
+  [:div {:hidden (nil? editted-cap-ref)}
+   [:form {:on-submit (call-prevent-default on-submit)}
+    [captured-ref-inputs {:value editted-cap-ref
+                          :on-change on-editted-cap-ref-change}]
+    [:button {:type "Submit"} "Submit"]]
+   [:div status]])
+
+(defn captured-ref-inputs [{:keys [value on-change]}]
   (letfn [(handle-change [k] (fn [x] (on-change (assoc value k x))))]
     [:div
      [:div

--- a/test/cljs/kti_web/core_test.cljs
+++ b/test/cljs/kti_web/core_test.cljs
@@ -41,6 +41,10 @@
         save-args (fn [& args] (swap! args-atom conj (into [] args)))]
     [args-atom save-args]))
 
+(defn prevent-default-event
+  ([] (prevent-default-event (constantly nil)))
+  ([f] (clj->js {:preventDefault f})))
+
 (deftest test-home
   (with-mounted-component (rc/home-page)
     (fn [c div]
@@ -56,7 +60,7 @@
                                         :on-selection (constantly nil)})]
       (go (>! cap-ref-chan {}))
       (is (= 123 (get-in comp [1 3 1 :value])))
-      ((get-in comp [1 1 :on-submit]) (clj->js {:preventDefault (fn [] nil)}))
+      ((get-in comp [1 1 :on-submit]) (prevent-default-event))
       (is (= [[123]] @get-captured-ref-args))))
   (testing "Calls on-id-change on selected id change"
     (let [[on-id-change-args on-id-change] (args-saver)
@@ -75,8 +79,7 @@
            (go
              (>! cap-ref-chan cap-ref)
              (let [out-chan
-                   ((get-in comp [1 1 :on-submit])
-                    (clj->js {:preventDefault (fn [] nil)}))]
+                   ((get-in comp [1 1 :on-submit]) (prevent-default-event))]
                (<! out-chan)
                (is (= [[cap-ref]] @on-selection-args))
                (done))))))
@@ -130,7 +133,7 @@
           on-change (get-in comp [2 2 1 :on-change])
           on-submit (get-in comp [2 1 :on-submit])]
       (on-change "foo")
-      (on-submit (clj->js {:preventDefault prevent-default}))
+      (on-submit (prevent-default-event prevent-default))
       (is (= @prevent-default-call-count 1))
       (async done (go (>! c {:id 1 :reference "foo"})
                       (<! c-done)
@@ -138,43 +141,76 @@
                              "Created with id 1 and ref foo"))
                       (done))))))
 
+(deftest test-edit-captured-ref-comp
+  (let [get-id-val #(get-in % [2 1 :id-value])
+        get-on-id-change #(get-in % [2 1 :on-id-change])
+        get-ref-form-on-selection #(get-in % [2 1 :on-selection])
+        get-on-submit #(get-in % [3 1 :on-submit])
+        cap-ref-form-hidden? #(get-in % [3 1 :hidden])
+        get-edit-form-props #(get-in % [3 1])]
+    (testing "Updates select-captured-ref current id"
+      (let [comp-1 (rc/edit-captured-ref-comp)]
+        (is (= nil (get-id-val (comp-1))))
+        ((get-on-id-change (comp-1)) 921)
+        (is (= 921 (get-id-val (comp-1))))))
+    (testing "Initializes edit-captured-ref-comp--form"
+      (let [cap-ref {:id 1 :reference "bar" :captured-at "baz"}
+            comp-1 (rc/edit-captured-ref-comp {})]
+        ;; User selects some cap-ref
+        ((get-ref-form-on-selection (comp-1)) cap-ref)
+        ;; And edit-captured-ref-comp--form has the correct props
+        (is (= (select-keys (get-edit-form-props (comp-1))
+                            [:editted-cap-ref :status]))
+               {:editted-cap-ref cap-ref :status nil})))
+    (testing "Calls put! on submit"
+      (let [[hput!-args save-hput!-args] (args-saver)
+            put-chan (chan 1)
+            hput! (fn [id cap-ref] (save-hput!-args id cap-ref) put-chan)
+            comp-1 (rc/edit-captured-ref-comp {:hput! hput!})]
+        (put! put-chan {})
+        ((get-on-id-change (comp-1)) 921)
+        ((get-ref-form-on-selection (comp-1)) {:id 921 :reference "foo"})
+        ((get-on-submit (comp-1)) (prevent-default-event))
+        (is (= [[921 {:id 921 :reference "foo"}]] @hput!-args))))))
+
 (deftest test-edit-captured-ref-form
-  (testing "Updates select-captured-ref current id"
-    (let [comp-1 (rc/edit-captured-ref-form)]
-      (is (= nil (get-in (comp-1) [2 1 :id-value :reference])))
-      ((get-in (comp-1) [2 1 :on-id-change]) 921)
-      (is (= 921 (get-in (comp-1) [2 1 :id-value])))))
-  (testing "Don't show captured-ref-form if no cap. ref. selected"
-    (let [cap-ref {:id 3 :reference "foo" :captured-at "bar"}
-          comp-1 (rc/edit-captured-ref-form)]
-      (is (= true (get-in (comp-1) [3 1 :hidden])))
-      ((get-in (comp-1) [2 1 :on-selection]) cap-ref)
-      (is (= false (get-in (comp-1) [3 1 :hidden])))))
-  (testing "Calls put! on submit"
-    (let [[hput!-args save-hput!-args] (args-saver)
-          put-chan (chan 1)
-          hput! (fn [id cap-ref] (save-hput!-args id cap-ref) put-chan)
-          comp-1 (rc/edit-captured-ref-form {:hput! hput!})]
-      (put! put-chan {})
-      ((get-in (comp-1) [2 1 :on-id-change]) 921)
-      ((get-in (comp-1) [2 1 :on-selection]) {:id 921 :reference "foo"})
-      ((get-in (comp-1) [3 3 1 :on-submit]) (clj->js {:preventDefault (fn [] nil)}))
-      (is (= [[921 {:id 921 :reference "foo"}]] @hput!-args)))))
+  (let [get-hidden #(get-in % [1 :hidden])
+        get-on-submit #(get-in % [2 1 :on-submit])
+        get-inputs-value #(get-in % [2 2 1 :value])
+        get-inputs-on-cap-ref-change #(get-in % [2 2 1 :on-change])
+        mount rc/edit-captured-ref-comp--form]
+    (testing "Is hidden unless editted-cap-ref is non nil"
+      (is (true? (get-hidden (mount {:editted-cap-ref nil}))))
+      (is (false? (get-hidden (mount {:editted-cap-ref {:a 1}})))))
+    (testing "Calls on-submit on form submittion"
+      (let [[on-submit-args on-submit] (args-saver)
+            event (prevent-default-event)]
+        ((get-on-submit (mount {:on-submit on-submit})) event)
+        (is (= @on-submit-args [[event]]))))
+    (testing "Value binding with captured-ref-inputs"
+      (let [[on-editted-cap-ref-change-args  on-editted-cap-ref-change]
+            (args-saver)
+            comp
+            (mount {:on-editted-cap-ref-change on-editted-cap-ref-change
+                    :editted-cap-ref {:a 1}})]
+        (is (= (get-inputs-value comp) {:a 1}))
+        ((get-inputs-on-cap-ref-change comp) {:b 2})
+        (is (= [[{:b 2}]] @on-editted-cap-ref-change-args))))))
 
 (deftest test-captured-ref-form
   (testing "Calls on-change if reference changes"
     (let [[on-change-args on-change] (args-saver)
-          comp (rc/captured-ref-form
+          comp (rc/captured-ref-inputs
                 {:value {:id 99 :reference "foo"} :on-change on-change})]
       (is (= "foo" (get-in comp [3 2 1 :value])))
       ((get-in comp [3 2 1 :on-change]) (clj->js {:target {:value "bar"}}))
       (is (= [[{:id 99 :reference "bar"}]] @on-change-args))))
   (testing "Id input is disabled"
-    (let [id 141 comp (rc/captured-ref-form {:value {:id id}})]
+    (let [id 141 comp (rc/captured-ref-inputs {:value {:id id}})]
       (is (= id (get-in comp [1 2 1 :value])))
       (is (= true (get-in comp [1 2 1 :disabled])))))
   (testing "Created at input is disabled"
-    (let [comp (rc/captured-ref-form {:value {:created-at "foo"}})]
+    (let [comp (rc/captured-ref-inputs {:value {:created-at "foo"}})]
       (is (= "foo" (get-in comp [2 2 1 :value])))
       (is (= true (get-in comp [2 2 1 :disabled]))))))
 
@@ -225,7 +261,7 @@
         (is (= [["foo"]] @update-ref-id-args)))
       (testing "Calls delete! on submit"
         (is (= [] @delete-args))
-        ((get-in comp [1 1 :on-submit]) (clj->js {:preventDefault fn-nothing}))
+        ((get-in comp [1 1 :on-submit]) (prevent-default-event))
         (is (= [[3]] @delete-args))))))
 
 (deftest test-run-req!-base


### PR DESCRIPTION
- Splits into
  - `edit-captured-ref-comp`
  - `edit-captured-ref--form`
  - `caputred-ref-inputs`
- Adds `prevent-default-event` to tests
- Adds more tests to edit captured ref