### PR TITLE
NEW Rewrites `run-req!` to return `{error? ... data ...}`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ pom.xml.asc
 /.env
 /.sass-cache
 node_modules
+/resources/public/css/site.min.css

--- a/src/cljs/kti_web/components/article_creator.cljs
+++ b/src/cljs/kti_web/components/article_creator.cljs
@@ -3,7 +3,7 @@
    [clojure.string :as str]
    [reagent.core :as r :refer [atom]]
    [cljs.core.async :refer [chan <! >! put! go]]
-   [kti-web.utils :refer [call-with-val call-prevent-default]]
+   [kti-web.utils :refer [call-with-val call-prevent-default] :as utils]
    [kti-web.components.utils :refer [submit-button]]))
 
 (defn parse-tags [x]
@@ -73,8 +73,9 @@
           (let [out-chan (chan)
                 resp-chan (hpost! (parse-article-spec @article-spec))]
             (go
-              (let [{:keys [error]} (<! resp-chan)]
-                (assert (nil? error) "Something went wrong on post call")
+              (let [{:keys [error? data]} (<! resp-chan)]
+                (when error?
+                  (utils/js-alert (str "Error: " (utils/to-str data))))
                 (>! out-chan 1)))
             out-chan))]
     (fn []

--- a/src/cljs/kti_web/utils.cljs
+++ b/src/cljs/kti_web/utils.cljs
@@ -1,7 +1,9 @@
-(ns kti-web.utils)
+(ns kti-web.utils
+  (:require [cljs.pprint]))
 
 ;; -------------------------
 ;; Utils
 (defn call-with-val [f] #(-> % .-target .-value f))
 (defn call-prevent-default [f] #(do (.preventDefault %) (f %)))
-
+(defn js-alert [x] (js/alert x))
+(defn to-str [x] (with-out-str (cljs.pprint/pprint x)))

--- a/test/cljs/kti_web/components/article_creator_test.cljs
+++ b/test/cljs/kti_web/components/article_creator_test.cljs
@@ -3,7 +3,8 @@
    [cljs.test :refer-macros [is are deftest testing use-fixtures async]]
    [cljs.core.async :refer [chan <! >! put! go]]
    [kti-web.components.article-creator :as rc]
-   [kti-web.test-utils :as utils]))
+   [kti-web.test-utils :as utils]
+   [kti-web.test-factories :as factories]))
 
 (deftest test-make-input
   (let [foo-input (rc/make-input {:text "Foo"})]
@@ -95,10 +96,7 @@
         hpost!-chan (chan)
         hpost! (fn [x] (hpost!-save-args x) hpost!-chan)
         comp-1 (rc/article-creator {:hpost! hpost!})
-        article-spec {:id-captured-reference "12"
-                      :description "Foo Bar"
-                      :tags "tag1, tag2"
-                      :action-link "www.google.com"}]
+        article-spec factories/article-raw-spec]
     ;; User fills the form with an article spec
     ((get-in (comp-1) [1 :on-article-spec-update]) article-spec)
     ;; And submits

--- a/test/cljs/kti_web/http_test.cljs
+++ b/test/cljs/kti_web/http_test.cljs
@@ -4,7 +4,8 @@
    [cljs.core.async :refer [>! <! take! put! go chan close!]]
    [kti-web.http :as rc]
    [kti-web.test-utils :as utils]
-   [kti-web.state :as state]))
+   [kti-web.state :as state]
+   [kti-web.test-factories :as factories]))
 
 (deftest test-prepare-request-opts
   (testing "No json-body"
@@ -17,12 +18,55 @@
             :headers {"authorization" (str "TOKEN " @state/token)}
             :json-params {:a :b}}))))
 
+(deftest test-parse-error-body
+  (testing "Only errors"
+    (let [errors {:a :b :c :d} body {:errors errors}]
+      (is (= (rc/parse-error-body body) errors))))
+  (testing "Only error-msg"
+    (let [error-msg "Foo" body {:error-msg error-msg}]
+      (is (= (rc/parse-error-body body) {:ROOT "Foo"}))))
+  (testing "errors and error-msg"
+    (let [error-msg "Foo"
+          errors {:a :b}
+          body {:errors errors :error-msg error-msg}]
+      (is (= (rc/parse-error-body body)
+             {:ROOT "Foo" :a :b})))))
+
+(deftest test-parse-error-response
+  (testing "500"
+    (is (= (rc/parse-error-response {:status 500})
+           {:ROOT rc/ERR-MSG--INTERNAL-SERVER-ERROR})))
+  (testing "404"
+    (is (= (rc/parse-error-response {:status 404})
+           {:ROOT rc/ERR-MSG--NOT-FOUND})))
+  (testing "401 and 403"
+    (are [code msg]
+        (= (rc/parse-error-response {:status code}) {:ROOT rc/ERR-MSG--INVALID-AUTH})
+      401
+      403))
+  (testing "Others, use parse-error-response"
+    (with-redefs [rc/parse-error-response (constantly {:ROOT ::foo})]
+      (are [code] (= (rc/parse-error-response {:status code}) {:ROOT ::foo})
+        400 300))))
+      
+
 (deftest test-parse-response
-  (testing "Errored"
-    (let [response {:success false :a :b}]
-      (is (= (rc/parse-response response) {:error true :response response}))))
-  (testing "Success"
-    (is (= (rc/parse-response {:success true :body :a})) :a)))
+  (testing "Errored with error-msg"
+    (is (= (rc/parse-response factories/http-response-error-msg)
+           {:error? true
+            :data
+            {:ROOT (get-in factories/http-response-error-msg [:body :error-msg])}})))
+  (testing "Errored with schema error"
+    (is (= (rc/parse-response factories/http-response-schema-error)
+           {:error? true
+            :data (get-in factories/http-response-schema-error [:body :errors])})))
+  (testing "OK"
+    (is (= (rc/parse-response {:success true :body {:a :b}})
+           {:data {:a :b}})))
+  (testing "Calls parse-error-body"
+    (with-redefs [rc/parse-error-body (constantly ::bar)]
+      (is (= (rc/parse-response {:success false})
+             {:error? true :data ::bar})))))
 
 (deftest test-run-req!-base
   (let [http-fn-chan (chan 1)
@@ -38,24 +82,20 @@
                                       :json-params json-params)]]))
     (async done
            (go (>! http-fn-chan {:success true :body 1})
-               (is (= 1 (<! chan)))
+               (is (= {:data 1} (<! chan)))
                (done)))))
 
 (deftest test-run-req!-error
-  (let [http-fn-chan (chan 1)
+  (let [http-fn-chan (chan)
         [http-fn-args save-http-fn-args] (utils/args-saver)
-        http-fn (fn [x y] (save-http-fn-args x y) http-fn-chan)]
-    ;; Runs the request and stores the channel
-    (let [res-chan (rc/run-req! {:http-fn http-fn :url 1})]
-      ;; http-fn should have been called with those args
-      (is (= @http-fn-args
-             [[1 {:with-credentials? false
-                  :headers {"authorization" (str "TOKEN " @state/token)}}]]))
-      (let [response {:success false :status 404}]
-        (async done
-               (go
-                 ;; Simulates the errored http response
-                 (>! http-fn-chan response)
-                 ;; And ensures that the error is written on the response channel
-                 (is (= {:error true :response response} (<! res-chan)))
-                 (done)))))))
+        http-fn #(do (save-http-fn-args %1 %2) http-fn-chan)]
+    ;; Calls the function to run the request
+    (let [res-chan (rc/run-req! {:http-fn http-fn :url :foo})]
+      (async done
+             (go
+               ;; Simulates an errored response
+               (>! http-fn-chan factories/http-response-schema-error)
+               ;; And checks that we received the response we expected
+               (is (= (<! res-chan)
+                      (rc/parse-response factories/http-response-schema-error)))
+               (done))))))

--- a/test/cljs/kti_web/test_factories.cljs
+++ b/test/cljs/kti_web/test_factories.cljs
@@ -1,0 +1,65 @@
+(ns kti-web.test-factories)
+
+(def http-response-schema-error
+  {:status 400
+   :success false
+   :body
+   {:schema
+    (str "{:id-captured-reference java.lang.Integer, :description java.lang.Str"
+         "ing, :action-link (maybe Str), :tags #{java.lang.String}}")
+    :errors
+    {:id-captured-reference "missing-required-key"
+     :action-link "missing-required-key"
+     :tags "missing-required-key"}
+    :type "compojure.api.exception/request-validation"
+    :coercion "schema"
+    :value {:description "Hola"}
+    :in ["request" "body-params"]}
+   :headers {"content-type" "application/json; charset=utf-8"}
+   :trace-redirects
+   ["http://159.65.192.68//api/articles"
+    "http://159.65.192.68//api/articles"]
+   :error-code :http-error,
+   :error-text "Bad Request [400]"})
+
+(def http-response-error-msg
+  {:status 400
+   :success false
+   :body
+   {:error-msg "Error message"}
+   :headers {"content-type" "application/json; charset=utf-8"}
+   :trace-redirects
+   ["http://159.65.192.68//api/articles"
+    "http://159.65.192.68//api/articles"]
+   :error-code :http-error,
+   :error-text "Bad Request [400]"})
+
+(def captured-ref
+  {:id 49
+   :reference "Foobarbaz"
+   :created-at "1993-11-23T11:12:15"
+   :classified false})
+
+(def article-raw-spec
+  {:id-captured-reference "12"
+   :description "Foo Bar"
+   :tags "tag1, tag2"
+   :action-link "www.google.com"})
+
+(defn ok-response
+  "Factory for responses with 200 and some data"
+  [body]
+  {:status 200,
+   :success true,
+   :body body,
+   :headers {"content-type" "application/json; charset=utf-8"},
+   :trace-redirects
+   ["http://159.65.192.68/api/captured-references"
+    "http://159.65.192.68/api/captured-references"],
+   :error-code :no-error, 
+   :error-text ""})
+
+(defn parsed-ok-response
+  "Factory for ok parsed http responses"
+  [data]
+  {:error? false :data data})


### PR DESCRIPTION
- `run-req!` parses errors and returns it on `data` with `error?` true
- Rewrites most request functions to show error data