### PR TITLE
NEW Adds article edditing functionality

### DIFF
--- a/src/cljs/kti_web/components/article_creator.cljs
+++ b/src/cljs/kti_web/components/article_creator.cljs
@@ -6,21 +6,14 @@
    [kti-web.models.articles :as articles]
    [kti-web.components.utils :refer [submit-button] :as components-utils]))
 
-(defn make-input [{:keys [text type]}]
-  "Makes an input component"
-  (fn [{:keys [value on-change]}]
-    [:div
-     [:span text]
-     [:input {:value value
-              :on-change (call-with-val on-change)
-              :type type}]
-     [:div (str "(current value: " value ")")]]))
-
 (def article-creator-inputs--id-captured-reference
-  (make-input {:text "Id Captued Reference" :type "number"}))
-(def article-creator-inputs--description (make-input {:text "Description"}))
-(def article-creator-inputs--tags (make-input {:text "Tags"}))
-(def article-creator-inputs--action-link (make-input {:text "Action Link"}))
+  (components-utils/make-input {:text "Id Captued Reference" :type "number"}))
+(def article-creator-inputs--description
+  (components-utils/make-input {:text "Description"}))
+(def article-creator-inputs--tags
+  (components-utils/make-input {:text "Tags"}))
+(def article-creator-inputs--action-link
+  (components-utils/make-input {:text "Action Link"}))
 
 (defn article-creator-form
   [{:keys [article-spec on-article-spec-update on-article-creation-submit]}]

--- a/src/cljs/kti_web/components/utils.cljs
+++ b/src/cljs/kti_web/components/utils.cljs
@@ -1,4 +1,17 @@
-(ns kti-web.components.utils)
+(ns kti-web.components.utils
+  (:require
+   [kti-web.utils :as utils]))
+
+(defn make-input [{:keys [text type disabled]}]
+  "Makes an input component"
+  (fn [{:keys [value on-change]}]
+    [:div
+     [:span text]
+     [:input {:style {:width 600}
+              :value value
+              :on-change (utils/call-with-val on-change)
+              :type type
+              :disabled (or disabled false)}]]))
 
 (defn submit-button
   ([] (submit-button {:text "Submit!"}))

--- a/src/cljs/kti_web/core.cljs
+++ b/src/cljs/kti_web/core.cljs
@@ -12,7 +12,9 @@
                          get-captured-references!
                          put-captured-reference!
                          delete-captured-reference!
-                         post-article!]]
+                         get-article!
+                         post-article!
+                         put-article!]]
    [kti-web.state :refer [token host api-url init-state]]
    [kti-web.components.edit-captured-reference-component
     :refer [edit-captured-ref-comp]]
@@ -68,7 +70,7 @@
      [:div
       [:h2 "Articles!"]
       [article-creator {:hpost! post-article!}]
-      [article-editor {}]
+      [article-editor {:get-article! get-article! :put-article! put-article!}]
       [article-deletor {}]
       [article-table {}]]]))
 

--- a/src/cljs/kti_web/http.cljs
+++ b/src/cljs/kti_web/http.cljs
@@ -79,8 +79,19 @@
    {:http-fn http/delete
     :url (api-url (str "captured-references/" id))}))
 
+(defn get-article! [id]
+  (run-req!
+   {:http-fn http/get
+    :url (api-url (str "articles/" id))}))
+
 (defn post-article! [article-spec]
   (run-req!
    {:http-fn http/post
     :url (api-url "articles")
+    :json-params article-spec}))
+
+(defn put-article! [id article-spec]
+  (run-req!
+   {:http-fn http/put
+    :url (api-url (str "articles/" id))
     :json-params article-spec}))

--- a/src/cljs/kti_web/models/articles.cljs
+++ b/src/cljs/kti_web/models/articles.cljs
@@ -26,7 +26,7 @@
   "Serializes an article spec."
   (->> x
        (map (fn [[k v]] [k ((make-serializer k) v)]))
-       (into {:action-link nil})))
+       (into {:action-link nil :tags []})))
 
 (defn article->raw
   "Converts an article in it's raw (string) representation"

--- a/test/cljs/kti_web/components/article_creator_test.cljs
+++ b/test/cljs/kti_web/components/article_creator_test.cljs
@@ -9,18 +9,6 @@
    [kti-web.test-utils :as utils]
    [kti-web.test-factories :as factories]))
 
-(deftest test-make-input
-  (let [foo-input (rc/make-input {:text "Foo"})]
-    (testing "Contains span with text"
-      (is (= (get-in (foo-input {}) [1]) [:span "Foo"])))
-    (testing "Binds value to input"
-      (is (= (get-in (foo-input {:value :a}) [2 1 :value]) :a)))
-    (testing "Calls on-change on change"
-      (let [[on-change-args on-change] (utils/args-saver)
-            comp (foo-input {:on-change on-change})]
-        ((get-in comp [2 1 :on-change]) (utils/target-value-event "foo"))
-        (is (= @on-change-args [["foo"]]))))))
-
 (deftest test-article-creator-form
   (let [mount rc/article-creator-form]
     (testing "Two-way binding with id-captured-reference"

--- a/test/cljs/kti_web/components/utils_test.cljs
+++ b/test/cljs/kti_web/components/utils_test.cljs
@@ -1,7 +1,22 @@
 (ns kti-web.components.utils-test
   (:require
    [cljs.test :refer-macros [is are deftest testing use-fixtures async]]
+   [kti-web.test-utils :as utils]
    [kti-web.components.utils :as rc]))
+
+(deftest test-make-input
+  (let [foo-input (rc/make-input {:text "Foo"})]
+    (testing "Contains span with text"
+      (is (= (get-in (foo-input {}) [1]) [:span "Foo"])))
+    (testing "Binds value to input"
+      (is (= (get-in (foo-input {:value :a}) [2 1 :value]) :a)))
+    (testing "Calls on-change on change"
+      (let [[on-change-args on-change] (utils/args-saver)
+            comp (foo-input {:on-change on-change})]
+        ((get-in comp [2 1 :on-change]) (utils/target-value-event "foo"))
+        (is (= @on-change-args [["foo"]]))))
+    (testing "Disabled"
+      (is (true? (get-in ((rc/make-input {:disabled true})) [2 1 :disabled]))))))
 
 (deftest test-errors-displayer
   (let [mount rc/errors-displayer]

--- a/test/cljs/kti_web/models/articles_test.cljs
+++ b/test/cljs/kti_web/models/articles_test.cljs
@@ -18,7 +18,11 @@
     (testing "Missing action-link"
       ;; If an action-link is missing, it should be nil
       (is (= (rc/serialize-article-spec (dissoc article-spec :action-link))
-             serialized-article-spec)))))
+             serialized-article-spec)))
+    (testing "Missing tags"
+      ;; If tags is missing, it should be and empty link
+      (is (= (rc/serialize-article-spec (dissoc article-spec :tags))
+             (assoc serialized-article-spec :tags []))))))
 
 (deftest test-article->raw
   (testing "Base"


### PR DESCRIPTION
- OPT Moves `make-input` to `components.utils`
- NEW Adds inputs, `article-editor-form`, `article-selector`,
  `article-editor--inner`.
- OPT Corrects state management functions for editting articles.
- NEW Adds `get-article!` and `put-article!` in `http`.
- OPT Defaults article `tags` to empty list on serialization.