### PR TITLE
OPT Extracts and refactors captured reference table

### DIFF
--- a/src/cljs/kti_web/components/captured_reference_table.cljs
+++ b/src/cljs/kti_web/components/captured_reference_table.cljs
@@ -1,0 +1,61 @@
+(ns kti-web.components.captured-reference-table
+  (:require [cljs.core.async :refer [<! >! go]]
+            [kti-web.utils :as utils :refer [js-alert]]
+            [reagent.core :as r]))
+
+(defn- captured-reference->tr
+  "Makes a <tr> from a captured reference."
+  [{:keys [id reference created-at classified]}]
+  [:tr {:key id}
+   [:td id]
+   [:td reference]
+   [:td created-at]
+   [:td (str classified)]])
+
+(defn captured-refs-table-inner
+  "Pure component for a table of captured references."
+  [{:keys [loading? refs fn-refresh!]}]
+  (let [headers ["id" "ref" "created at" "classified?"]]
+    [:div
+     [:h3 "Captured References Table"]
+     [:button {:on-click fn-refresh!} "Update"]
+     (if loading?
+       [:div "LOADING..."]
+       [:table
+        [:thead [:tr (map (fn [x] [:th {:key x} x]) headers)]]
+        [:tbody (->> refs
+                     (sort-by :created-at)
+                     reverse
+                     (map captured-reference->tr))]])]))
+
+(def initial-state
+  "The initial state for the captured reference table."
+  {:loading true :refs nil})
+
+(defn- reduce-before-get-all-captured-references
+  [state]
+  (assoc state :loading? true :refs nil))
+
+(defn- reduce-get-all-captured-references-response
+  [{:keys [error? data] :as resp}]
+  (fn [state]
+    (if error?
+      (do
+        (js-alert (str "Error during get: " (:ROOT data)))
+        (assoc state :loading? false :refs []))
+      (assoc state :loading? false :refs data))))
+
+(defn captured-refs-table [{:keys [get! c-done]}]
+  (let [state (r/atom initial-state)
+        run-get!
+        (fn []
+          (swap! state reduce-before-get-all-captured-references)
+          (let [get-chan (get!)]
+            (go
+              (->> get-chan
+                   <!
+                   reduce-get-all-captured-references-response
+                   (swap! state))
+              (and c-done (>! c-done 1)))))]
+    (run-get!)
+    #(captured-refs-table-inner (assoc @state :fn-refresh! run-get!))))

--- a/test/cljs/kti_web/components/captured_reference_table_test.cljs
+++ b/test/cljs/kti_web/components/captured_reference_table_test.cljs
@@ -1,0 +1,40 @@
+(ns kti-web.components.captured-reference-table-test
+  (:require [cljs.core.async :refer [<! >! chan go]]
+            [cljs.test :refer-macros [async deftest is]]
+            [kti-web.components.captured-reference-table :as rc]
+            [kti-web.http :as http]
+            [kti-web.test-factories :as factories]
+            [kti-web.test-utils :as utils]))
+
+(deftest test-captured-refs-table
+  (let [c (chan 1)
+        c-done (chan 1)
+        comp-1 (rc/captured-refs-table {:get! (constantly c) :c-done c-done})]
+    (is (= [:div "LOADING..."] (get (comp-1) 3)))
+    (async done
+           (go (>! c [factories/captured-ref])
+               (<! c-done)
+               (is (= :table (get-in (comp-1) [3 0])))
+               (is (= :thead (get-in (comp-1) [3 1 0])))
+               (is (= ["id" "ref" "created at" "classified?"]
+                      (-> (comp-1) (get-in [3 1 1 1]) (->> (map #(get % 2))))))
+               (done)))))
+
+(deftest test-captured-refs-table--alerts-on-error
+  (let [req-chan (chan)
+        done-chan (chan)
+        error (http/parse-response factories/http-response-error-msg)
+        comp-1 (rc/captured-refs-table
+                {:get! (constantly req-chan) :c-done done-chan})]
+    (async done
+           (go
+             ;; Captures js/alert
+             (let [[js-alert-args js-alert] (utils/args-saver)]
+               (with-redefs [kti-web.utils/js-alert js-alert]
+                 ;; Requests returns an error
+                 (>! req-chan error)
+                 (<! done-chan)
+                 ;; That was passed to js/alert
+                 (is (= @js-alert-args
+                        [[(str "Error during get: " (get-in error [:data :ROOT]))]]))
+                 (done)))))))

--- a/test/cljs/kti_web/core_test.cljs
+++ b/test/cljs/kti_web/core_test.cljs
@@ -120,42 +120,7 @@
              (<! done-chan)
              ;; Results is corrects
              (is (= [:div "Created with id 49 and ref Foobarbaz"] (get-result-div)))
-             (done)))))
-    
-
-(deftest test-captured-refs-table
-  (let [c (chan 1)
-        c-done (chan 1)
-        comp-1 (rc/captured-refs-table {:get! (constantly c) :c-done c-done})]
-    (is (= [:div "LOADING..."] (get (comp-1) 3)))
-    (async done
-           (go (>! c [factories/captured-ref])
-               (<! c-done)
-               (is (= :table (get-in (comp-1) [3 0])))
-               (is (= :thead (get-in (comp-1) [3 1 0])))
-               (is (= ["id" "ref" "created at" "classified?"]
-                      (-> (comp-1) (get-in [3 1 1 1]) (->> (map #(get % 2))))))
-               (done)))))
-
-(deftest test-captured-refs-table--alerts-on-error
-  (let [req-chan (chan)
-        done-chan (chan)
-        error (http/parse-response factories/http-response-error-msg)
-        comp-1 (rc/captured-refs-table
-                {:get! (constantly req-chan) :c-done done-chan})]
-    (async done
-           (go
-             ;; Captures js/alert
-             (let [[js-alert-args js-alert] (utils/args-saver)]
-               (with-redefs [kti-web.utils/js-alert js-alert]
-                 ;; Requests returns an error
-                 (>! req-chan error)
-                 (<! done-chan)
-                 ;; That was passed to js/alert
-                 (is (= @js-alert-args
-                        [[(str "Error during get: " (get-in error [:data :ROOT]))]]))
-                 (done)))))))
-             
+             (done)))))             
 
 (deftest test-delete-captured-ref-form
   (let [get-result-div #(get-in % [1 7])

--- a/test/cljs/kti_web/doo_runner.cljs
+++ b/test/cljs/kti_web/doo_runner.cljs
@@ -8,7 +8,8 @@
             [kti-web.components.utils-test]
             [kti-web.models.articles-test]
             [kti-web.components.article-editor-test]
-            [kti-web.components.article-deletor-test]))
+            [kti-web.components.article-deletor-test]
+            [kti-web.components.captured-reference-table-test]))
 
 (doo-tests 'kti-web.core-test
            'kti-web.http-test
@@ -18,4 +19,5 @@
            'kti-web.components.article-creator-test
            'kti-web.models.articles-test
            'kti-web.components.article-editor-test
-           'kti-web.components.article-deletor-test)
+           'kti-web.components.article-deletor-test
+           'kti-web.components.captured-reference-table-test)


### PR DESCRIPTION
- Takes `captured-reference-table` away from `core.cljs`.
- Creates `src/cljs/kti_web/components/captured_reference_table.cljs`.
- Splits `captured-reference-table` into more (pure) functions.
- OPT Sorts imports for core.cljs.