### PR TITLE
NEW Implements high level interface for create-review

### DIFF
--- a/src/cljc/kti_web/utils.cljc
+++ b/src/cljc/kti_web/utils.cljc
@@ -1,0 +1,12 @@
+(ns kti-web.utils)
+
+(defmacro go-with-done-chan
+  "Executes body in a go block, returning a channel in which :done is written
+   as the last step of the go block."
+  {:style/indent 0}
+  [& body]
+  `(let [resp-chan# (cljs.core.async/chan)]
+     (cljs.core.async/go
+       ~@body
+       (cljs.core.async/>! resp-chan# :done))
+     resp-chan#))

--- a/src/cljs/kti_web/components/review_creator.cljs
+++ b/src/cljs/kti_web/components/review_creator.cljs
@@ -1,5 +1,50 @@
-(ns kti-web.components.review-creator)
+(ns kti-web.components.review-creator
+  (:require
+   [kti-web.utils :refer-macros [go-with-done-chan]]
+   [kti-web.models.reviews :as review-models]
+   [reagent.core :as r :refer [atom]]
+   [cljs.core.async :as async :refer [>! <! go]]))
 
-(defn review-creator
+(defn review-creator-inner
+  "Pure component for review creation."
   [specs]
   [:span "NOT IMPLEMENTED"])
+
+(def initial-state
+  {:loading? false
+   :status {}
+   :review-raw-spec {}})
+
+(defn make-success-msg [{:keys [id]}] (str "Created review with id" id))
+
+(defn reduce-before-review-creation-submit
+  "Prepares state before a review creation submit"
+  [state]
+  (assoc state :loading? true :status {}))
+
+(defn reduce-review-creation-submit-response
+  "Sets state with the response of submitting for review creation"
+  [state {:keys [error? data] :as resp}]
+  (assoc state
+         :loading? false
+         :status (if error?
+                   {:errors data}
+                   {:success-msg (make-success-msg data)})))
+
+(defn review-creator
+  [{:keys [post-review!]}]
+  (let [state (atom initial-state)]
+    (letfn [(handle-review-creation-submit []
+              (swap! state reduce-before-review-creation-submit)
+              (go-with-done-chan
+               (->> @state
+                    :review-raw-spec
+                    review-models/raw-spec->spec
+                    post-review!
+                    <!
+                    (swap! state reduce-review-creation-submit-response))))]
+      (fn []
+        [review-creator-inner
+         (assoc @state
+                :on-review-raw-spec-change #(swap! state assoc :review-raw-spec %)
+                :on-review-creation-submit handle-review-creation-submit)]))))

--- a/src/cljs/kti_web/models/reviews.cljs
+++ b/src/cljs/kti_web/models/reviews.cljs
@@ -1,0 +1,18 @@
+(ns kti-web.models.reviews)
+
+(defn raw-status->status
+  "Converts from a string to a status"
+  [v]
+  (case v
+    "in-progress" :in-progress
+    "completed"   :completed
+    "discarded"   :discarded
+    (throw (str "Unkown status " v))))
+
+(defn raw-spec->spec
+  "Converts from review raw-spec into a spec"
+  [raw-spec]
+  (into {} (map (fn [[k v]] [k (case k
+                                 :status (raw-status->status v)
+                                 v)])
+                raw-spec)))

--- a/test/cljs/kti_web/components/review_creator_test.cljs
+++ b/test/cljs/kti_web/components/review_creator_test.cljs
@@ -1,4 +1,72 @@
 (ns kti-web.components.review-creator-test
-  (:require [kti-web.components.review-creator :as sut]
-            [cljs.test :as t :include-macros true]))
+  (:require
+   [cljs.test :refer-macros [is are deftest testing use-fixtures async]]
+   [cljs.core.async :refer [chan <! >! put! go] :as async]
+   [kti-web.http :as http]
+   [kti-web.components.review-creator :as rc]
+   [kti-web.models.reviews :as review-models]
+   [kti-web.components.utils :as components-utils]
+   [kti-web.models.articles :as articles]
+   [kti-web.test-utils :as utils]
+   [kti-web.test-factories :as factories]))
 
+;; Helpers
+(defn get-prop-review-creator-inner
+  [c k]
+  (get-in c [1 k]))
+
+;; Tests
+(deftest test-reduce-before-review-creation-submit
+  (is (= (rc/reduce-before-review-creation-submit {})
+         {:status {} :loading? true})))
+
+(deftest test-reduce-review-creation-submit-response
+  (is (= (rc/reduce-review-creation-submit-response
+          {}
+          {:error? true :data {::a ::b}})
+         {:loading? false :status {:errors {::a ::b}}}))
+  (is (= (rc/reduce-review-creation-submit-response
+          {:review-raw-spec ::a :loading? true :status {:errors {}}}
+          {:error? false :data {:id 99}})
+         {:review-raw-spec ::a
+          :loading? false
+          :status {:success-msg (rc/make-success-msg {:id 99})}})))
+
+(deftest test-review-creator
+  (let [mount rc/review-creator
+        get-prop get-prop-review-creator-inner]
+    (testing "Updates review-raw-spec"
+      (let [comp1 (mount {})]
+        (is (= (get-prop (comp1) :review-raw-spec) {}))
+        ((get-prop (comp1) :on-review-raw-spec-change) factories/review-raw-spec)
+        (is (= (get-prop (comp1) :review-raw-spec) factories/review-raw-spec))))))
+
+(deftest test-review-creator--submit
+  (let [get-prop get-prop-review-creator-inner
+        [post!-args post!-args-saver] (utils/args-saver)
+        post!-chan (async/timeout 4000)
+        post! #(do (apply post!-args-saver %&) post!-chan)
+        comp1 (rc/review-creator {:post-review! post!})]
+    ;; State is not loading
+    (is (false? (get-prop (comp1) :loading?)))
+    ;; User enters the values for the review
+    ((get-prop (comp1) :on-review-raw-spec-change) factories/review-raw-spec)
+    ;; And submits
+    (let [done-chan ((get-prop (comp1) :on-review-creation-submit))]
+      ;; We are now loading
+      (is (true? (get-prop (comp1) :loading?)))
+      (async
+       done
+       (go
+         ;; And we see a call to post!
+         (is (= @post!-args
+                [[(review-models/raw-spec->spec factories/review-raw-spec)]]))
+         ;; We answer it
+         (>! post!-chan {:data factories/review})
+         (is (= :done (<! done-chan)))
+         ;; We are no longer loading
+         (is (false? (get-prop (comp1) :loading?)))
+         ;; And we see the success-msg
+         (is (= (get-prop (comp1) :status)
+                {:success-msg (rc/make-success-msg factories/review)}))
+         (done))))))

--- a/test/cljs/kti_web/doo_runner.cljs
+++ b/test/cljs/kti_web/doo_runner.cljs
@@ -12,7 +12,8 @@
             [kti-web.components.captured-reference-table-test]
             [kti-web.components.review-editor-test]
             [kti-web.components.review-deletor-test]
-            [kti-web.components.review-creator-test]))
+            [kti-web.components.review-creator-test]
+            [kti-web.models.reviews-test]))
 
 (doo-tests 'kti-web.core-test
            'kti-web.http-test
@@ -26,4 +27,5 @@
            'kti-web.components.captured-reference-table-test
            'kti-web.components.review-editor-test
            'kti-web.components.review-deletor-test
-           'kti-web.components.review-creator-test)
+           'kti-web.components.review-creator-test
+           'kti-web.models.reviews-test)

--- a/test/cljs/kti_web/models/reviews_test.cljs
+++ b/test/cljs/kti_web/models/reviews_test.cljs
@@ -1,0 +1,9 @@
+(ns kti-web.models.reviews-test
+  (:require
+   [cljs.test :refer-macros [is are deftest testing use-fixtures async]]
+   [kti-web.models.reviews :as rc]))
+
+(deftest test-raw-spec->spec
+  (is (= ((rc/raw-spec->spec
+           {:id-article 99 :feedback-text "Foo" :status "in-progress"})
+         {:id-article 99 :feedback-text "Foo" :status :in-progress}))))

--- a/test/cljs/kti_web/test_factories.cljs
+++ b/test/cljs/kti_web/test_factories.cljs
@@ -53,6 +53,17 @@
    :tags ["tag1" "tag2"]
    :action-link "www.gihub.com/vitorqb"})
 
+(def review-raw-spec
+  {:id-article 12
+   :feedback-text "The Foo"
+   :status "in-progress"})
+
+(def review
+  {:id 823
+   :id-article 121
+   :feedback-text "It rocks!"
+   :status "completed"})
+
 (defn ok-response
   "Factory for responses with 200 and some data"
   [body]


### PR DESCRIPTION
- OPT Adds `go-with-done-chan` macro for a go block returning a
  channel where :done is written on go block completion