### PR TITLE
NEW Adds `review-creator-form` and implements `review-creator-inner`

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,8 @@
                   :exclusions [org.clojure/tools.reader]]
                  [binaryage/oops "0.7.0"]
                  [cljs-http "0.1.46"]
-                 [pjstadig/humane-test-output "0.9.0"]]
+                 [pjstadig/humane-test-output "0.9.0"]
+                 [cljsjs/react-select "2.4.3-0"]]
 
   :plugins [[lein-environ "1.1.0"]
             [lein-cljsbuild "1.1.7"]

--- a/src/cljs/kti_web/components/review_creator.cljs
+++ b/src/cljs/kti_web/components/review_creator.cljs
@@ -1,14 +1,41 @@
 (ns kti-web.components.review-creator
   (:require
-   [kti-web.utils :refer-macros [go-with-done-chan]]
+   [kti-web.utils :refer-macros [go-with-done-chan] :as utils]
+   [kti-web.components.utils
+    :as component-utils
+    :refer [make-input make-select]]
    [kti-web.models.reviews :as review-models]
+   [kti-web.components.utils :as components-utils]
    [reagent.core :as r :refer [atom]]
    [cljs.core.async :as async :refer [>! <! go]]))
 
+(def inputs
+  {:id-article    (make-input  {:text "Article Id" :type "number"})
+   :feedback-text (make-input  {:text "Feedback Text" :type "text"})
+   :status        (make-select {:text "Status"
+                                :options review-models/raw-status})})
+
+(defn review-creator-form
+  "Pure form component for creation of a review."
+  [{:keys [review-raw-spec on-review-raw-spec-change on-review-creation-submit]}]
+  (let [handle-change
+        (fn [k v] (on-review-raw-spec-change (assoc review-raw-spec k v)))
+        render-input
+        (fn [k]
+          [(inputs k) {:value (k review-raw-spec) :on-change #(handle-change k %)}])]
+    [:form {:on-submit (utils/call-prevent-default #(on-review-creation-submit))}
+     (render-input :id-article)
+     (render-input :feedback-text)
+     (render-input :status)
+     [component-utils/submit-button]]))
+
 (defn review-creator-inner
   "Pure component for review creation."
-  [specs]
-  [:span "NOT IMPLEMENTED"])
+  [{{:keys [errors]} :status :as specs}]
+  [:div
+   [:h3 "Create Review"]
+   [review-creator-form specs]
+   [components-utils/errors-displayer {:errors errors}]])
 
 (def initial-state
   {:loading? false

--- a/src/cljs/kti_web/components/utils.cljs
+++ b/src/cljs/kti_web/components/utils.cljs
@@ -1,9 +1,28 @@
 (ns kti-web.components.utils
   (:require
-   [kti-web.utils :as utils]))
+   [kti-web.utils :as utils]
+   [reagent.core :as r]
+   [cljsjs.react-select]))
 
-(defn make-input [{:keys [text type disabled width]}]
+(defn select
+  "Wrapper around react-select providing a select component"
+  [{:keys [value on-change options]}]
+  [(r/adapt-react-class js/Select)
+   {:value     {:value value :label value}
+    :options   (map (fn [x] {:value x :label x}) options)
+    :on-change #(-> % js->clj (get "value") on-change)}])
+
+(defn make-select
+  "Makes a select component. Options must be an array of strings."
+  [{:keys [text options]}]
+  (fn [{:keys [value on-change]}]
+    [:<>
+     [:span text]
+     [select {:options options :on-change on-change :value value}]]))
+
+(defn make-input
   "Makes an input component"
+  [{:keys [text type disabled width]}]
   (fn [{:keys [value on-change]}]
     [:<>
      [:span text]

--- a/src/cljs/kti_web/core.cljs
+++ b/src/cljs/kti_web/core.cljs
@@ -25,7 +25,8 @@
               post-article!
               post-captured-reference!
               put-article!
-              put-captured-reference!]]
+              put-captured-reference!
+              post-review!]]
             [kti-web.state :refer [host init-state token]]
             [kti-web.utils :as utils :refer [call-prevent-default call-with-val]]
             [reagent.core :as r]
@@ -79,7 +80,7 @@
       [article-deletor {:delete-article! delete-article!}]]
      [:div
       [:h2 "Reviews"]
-      [review-creator {}]
+      [review-creator {:post-review! post-review!}]
       [review-editor {}]
       [review-deletor {}]]]))
 

--- a/src/cljs/kti_web/http.cljs
+++ b/src/cljs/kti_web/http.cljs
@@ -100,3 +100,9 @@
   (run-req!
    {:http-fn http/delete
     :url (api-url (str "articles/" id))}))
+
+(defn post-review! [spec]
+  (run-req!
+   {:http-fn http/post
+    :url (api-url "reviews")
+    :json-params spec}))

--- a/src/cljs/kti_web/models/reviews.cljs
+++ b/src/cljs/kti_web/models/reviews.cljs
@@ -1,18 +1,22 @@
 (ns kti-web.models.reviews)
 
+(def raw-status ["in-progress" "completed" "discarded"])
+(def status     [:in-progress  :completed  :discarded])
+
 (defn raw-status->status
   "Converts from a string to a status"
   [v]
-  (case v
-    "in-progress" :in-progress
-    "completed"   :completed
-    "discarded"   :discarded
-    (throw (str "Unkown status " v))))
+  (loop [[raw raw-rest] raw-status [key key-rest] status]
+    (cond
+      (nil? raw) (throw (str "Unkown status " v))
+      (= raw v)  key
+      :else      (recur raw-rest key-rest))))
 
 (defn raw-spec->spec
   "Converts from review raw-spec into a spec"
   [raw-spec]
   (into {} (map (fn [[k v]] [k (case k
                                  :status (raw-status->status v)
+                                 :id-article (js/parseInt v)
                                  v)])
                 raw-spec)))

--- a/test/cljs/kti_web/components/utils_test.cljs
+++ b/test/cljs/kti_web/components/utils_test.cljs
@@ -4,6 +4,22 @@
    [kti-web.test-utils :as utils]
    [kti-web.components.utils :as rc]))
 
+(deftest test-select
+  (let [mount rc/select]
+    (testing "Initializes with correct options"
+      (let [options ["foo" "bar"] comp (mount {:options options})]
+        ;; Select accepts {:label x :value x}
+        (is (= (get-in comp [1 :options])
+               (map #(hash-map :value % :label %) options)))))
+    (testing "Initializes with correct value"
+      (let [comp (mount {:value "foo"})]
+        (is (= (get-in comp [1 :value]) {:value "foo" :label "foo"}))))
+    (testing "Calls on-change on change"
+      (let [[args fun] (utils/args-saver)
+            comp (mount {:options ["foo"] :on-change fun})]
+        ((get-in comp [1 :on-change]) {"value" "foo" "label" "foo"})
+        (is (= @args [["foo"]]))))))
+
 (deftest test-make-input
   (let [foo-input (rc/make-input {:text "Foo"})]
     (testing "Contains span with text"

--- a/test/cljs/kti_web/models/reviews_test.cljs
+++ b/test/cljs/kti_web/models/reviews_test.cljs
@@ -5,5 +5,5 @@
 
 (deftest test-raw-spec->spec
   (is (= ((rc/raw-spec->spec
-           {:id-article 99 :feedback-text "Foo" :status "in-progress"})
+           {:id-article "99" :feedback-text "Foo" :status "in-progress"})
          {:id-article 99 :feedback-text "Foo" :status :in-progress}))))


### PR DESCRIPTION
- NEW Adds inputs for review creation and implements on
  `review-creator-form`.
- NEW Adds `select` component and `make-select` wrapper. Uses
  react-select.
- NEW Implements `review-creator-inner`.
- NEW Creates `post-review!` http request