### PR TITLE
NEW Disables form inputs and button during submit for review creation

### DIFF
--- a/src/cljs/kti_web/components/review_creator.cljs
+++ b/src/cljs/kti_web/components/review_creator.cljs
@@ -17,17 +17,20 @@
 
 (defn review-creator-form
   "Pure form component for creation of a review."
-  [{:keys [review-raw-spec on-review-raw-spec-change on-review-creation-submit]}]
+  [{:keys [review-raw-spec on-review-raw-spec-change on-review-creation-submit
+           loading?]}]
   (let [handle-change
         (fn [k v] (on-review-raw-spec-change (assoc review-raw-spec k v)))
         render-input
         (fn [k]
-          [(inputs k) {:value (k review-raw-spec) :on-change #(handle-change k %)}])]
+          [(inputs k) {:value (k review-raw-spec)
+                       :on-change #(handle-change k %)
+                       :temp-disabled loading?}])]
     [:form {:on-submit (utils/call-prevent-default #(on-review-creation-submit))}
      (render-input :id-article)
      (render-input :feedback-text)
      (render-input :status)
-     [component-utils/submit-button]]))
+     [component-utils/submit-button {:disabled loading?}]]))
 
 (defn review-creator-inner
   "Pure component for review creation."

--- a/src/cljs/kti_web/components/utils.cljs
+++ b/src/cljs/kti_web/components/utils.cljs
@@ -6,35 +6,40 @@
 
 (defn select
   "Wrapper around react-select providing a select component"
-  [{:keys [value on-change options]}]
+  [{:keys [value on-change options disabled]}]
   [(r/adapt-react-class js/Select)
-   {:value     {:value value :label value}
-    :options   (map (fn [x] {:value x :label x}) options)
-    :on-change #(-> % js->clj (get "value") on-change)}])
+   {:value      {:value value :label value}
+    :options    (map (fn [x] {:value x :label x}) options)
+    :on-change  #(-> % js->clj (get "value") on-change)
+    :isDisabled (or disabled false)}])
 
 (defn make-select
   "Makes a select component. Options must be an array of strings."
-  [{:keys [text options]}]
-  (fn [{:keys [value on-change]}]
+  [{:keys [text options perm-disabled]}]
+  (fn [{:keys [value on-change temp-disabled]}]
     [:<>
      [:span text]
-     [select {:options options :on-change on-change :value value}]]))
+     [select {:options options
+              :on-change on-change
+              :value value
+              :disabled (or perm-disabled temp-disabled false)}]]))
 
 (defn make-input
   "Makes an input component"
-  [{:keys [text type disabled width]}]
-  (fn [{:keys [value on-change]}]
+  [{:keys [text type perm-disabled width]}]
+  (fn [{:keys [value on-change temp-disabled]}]
     [:<>
      [:span text]
      [:input {:style {:width (or width 600)}
               :value value
               :on-change (utils/call-with-val on-change)
               :type type
-              :disabled (or disabled false)}]]))
+              :disabled (or perm-disabled temp-disabled false)}]]))
 
 (defn submit-button
   ([] (submit-button {:text "Submit!"}))
-  ([{:keys [text]}] [:button {:type "Submit"} text]))
+  ([{:keys [text disabled]}]
+   [:button {:type "submit" :disabled (or disabled false)} (or text "Submit!")]))
 
 (defn- errors-displayer-tree
   "Recursively renders a <li> and <ul> tree of errors

--- a/src/cljs/kti_web/models/reviews.cljs
+++ b/src/cljs/kti_web/models/reviews.cljs
@@ -6,7 +6,7 @@
 (defn raw-status->status
   "Converts from a string to a status"
   [v]
-  (loop [[raw raw-rest] raw-status [key key-rest] status]
+  (loop [[raw & raw-rest] raw-status [key & key-rest] status]
     (cond
       (nil? raw) (throw (str "Unkown status " v))
       (= raw v)  key

--- a/test/cljs/kti_web/components/article_editor_test.cljs
+++ b/test/cljs/kti_web/components/article_editor_test.cljs
@@ -16,8 +16,8 @@
         (is (= (get-in comp [2 0]) rc/id-input))
         ;; Has correct value
         (is (= (get-in comp [2 1 :value]) 87))
-        ;; Is disabled
-        (is (= (get-in comp [2 1 :disabled] true)))))
+        ;; Is permanently disabled
+        (is (= (get-in comp [2 1 :perm-disabled] true)))))
     (testing "id-cap-ref-input"
       (let [[args fun] (utils/args-saver)
             comp (mount {:raw-editted-article factories/article-raw-spec

--- a/test/cljs/kti_web/components/review_creator_test.cljs
+++ b/test/cljs/kti_web/components/review_creator_test.cljs
@@ -17,7 +17,8 @@
 
 ;; Tests
 (deftest test-review-creator-form
-  (let [mount rc/review-creator-form]
+  (let [mount rc/review-creator-form
+        get-submit-button #(get-in % [5])]
     (testing "Changing id-article"
       (let [id 9
             new-id 8
@@ -49,7 +50,15 @@
       (let [[args fun] (utils/args-saver)
             comp (mount {:on-review-creation-submit fun})]
         ((get-in comp [1 :on-submit]) (utils/prevent-default-event))
-        (is (= @args [[]]))))))
+        (is (= @args [[]]))))
+    (let [normal-comp (mount {:loading false})
+          loading-comp (mount {:loading? true})]
+      (testing "Disables inputs when loading"
+        (are [i] (true? (get-in loading-comp [i 1 :temp-disabled])) 2 3 4)
+        (are [i] (nil? (get-in normal-comp [i 1 :temp-disabled])) 2 3 4))
+      (testing "Disables button when loading"
+        (is (true? (->  loading-comp get-submit-button (get-in [1 :disabled]))))
+        (is (nil? (->  normal-comp get-submit-button (get-in [1 :disabled]))))))))
 
 (deftest test-review-creator-inner
   (let [mount rc/review-creator-inner


### PR DESCRIPTION
- NEW Adds :temp-disabled and :perm-disabled keys for `input` and
  `select` components.
- FIX Corrects bug on `raw-status->status