### PR TITLE
NEW Uses textarea in review creator

### DIFF
--- a/src/cljs/kti_web/components/article_editor.cljs
+++ b/src/cljs/kti_web/components/article_editor.cljs
@@ -6,7 +6,7 @@
    [kti-web.components.utils :as components-utils]
    [cljs.core.async :refer [chan <! >! put! go] :as async]))
 
-(def id-input (components-utils/make-input {:text "Id" :disabled true}))
+(def id-input (components-utils/make-input {:text "Id" :perm-disabled true}))
 (def id-cap-ref-input (components-utils/make-input {:text "Captured Ref. Id"}))
 (def description-input (components-utils/make-input {:text "Description"}))
 (def tags-input (components-utils/make-input {:text "Tags"}))

--- a/src/cljs/kti_web/components/review_creator.cljs
+++ b/src/cljs/kti_web/components/review_creator.cljs
@@ -3,17 +3,17 @@
    [kti-web.utils :refer-macros [go-with-done-chan] :as utils]
    [kti-web.components.utils
     :as component-utils
-    :refer [make-input make-select]]
+    :refer [make-input make-select make-textarea]]
    [kti-web.models.reviews :as review-models]
    [kti-web.components.utils :as components-utils]
    [reagent.core :as r :refer [atom]]
    [cljs.core.async :as async :refer [>! <! go]]))
 
 (def inputs
-  {:id-article    (make-input  {:text "Article Id" :type "number"})
-   :feedback-text (make-input  {:text "Feedback Text" :type "text"})
-   :status        (make-select {:text "Status"
-                                :options review-models/raw-status})})
+  {:id-article    (make-input     {:text "Article Id" :type "number"})
+   :feedback-text (make-textarea  {:text "Feedback Text" :type "text"})
+   :status        (make-select    {:text "Status"
+                                   :options review-models/raw-status})})
 
 (defn review-creator-form
   "Pure form component for creation of a review."

--- a/src/cljs/kti_web/components/utils.cljs
+++ b/src/cljs/kti_web/components/utils.cljs
@@ -36,6 +36,18 @@
               :type type
               :disabled (or perm-disabled temp-disabled false)}]]))
 
+(defn make-textarea
+  "Makes an textarea component"
+  [{:keys [text perm-disabled]}]
+  (fn [{:keys [rows cols value on-change temp-disabled]}]
+    [:<>
+     [:span text]
+     [:textarea {:rows (or rows 5)
+                 :cols (or cols 73)
+                 :disabled (or perm-disabled temp-disabled false)
+                 :value value
+                 :on-change (utils/call-with-val on-change)}]]))
+
 (defn submit-button
   ([] (submit-button {:text "Submit!"}))
   ([{:keys [text disabled]}]

--- a/test/cljs/kti_web/components/utils_test.cljs
+++ b/test/cljs/kti_web/components/utils_test.cljs
@@ -57,6 +57,30 @@
       (is (true? (get-disabled-prop
                   ((rc/make-input {:perm-disabled true}) {:temp-disabled true})))))))
 
+(deftest test-make-textarea
+  (let [get-disabled #(get-in % [2 1 :disabled])]
+    (testing "Renders components"
+      (let [comp ((rc/make-textarea {:text "foo"}) {})]
+        (is (= (get comp 0) :<>))
+        (is (= (get comp 1) [:span "foo"]))
+        (is (= (get-in comp [2 0]) :textarea))))
+    (testing "Passes props"
+      (are [k] (= (get-in ((rc/make-textarea {}) {k ::foo}) [2 1 k]) ::foo)
+        :value
+        :rows
+        :cols))
+    (testing "Calls on-change"
+      (let [[args fun] (utils/args-saver)]
+        (-> ((rc/make-textarea {}) {:on-change fun})
+            (get-in [2 1 :on-change])
+            (apply [(utils/target-value-event "foo")]))
+        (is (= @args [["foo"]]))))
+    (testing "Disabled"
+      (are [f props] (f (get-disabled ((rc/make-textarea {}) props)))
+        false? {}
+        false? {:temp-disabled false}
+        true?  {:temp-disabled true}))))
+
 (deftest test-errors-displayer
   (let [mount rc/errors-displayer]
     (testing "Don't show if errors is nil or {}"


### PR DESCRIPTION
- NEW Adds `make-textarea` for creating textarea components
- FIX corrects bug `:disabled` -> `:perm-disabled` for article editor
- NEW Uses `make-textarea` for