### PR TITLE
NEW Fully implements review editting

### DIFF
--- a/src/cljs/kti_web/components/review_editor.cljs
+++ b/src/cljs/kti_web/components/review_editor.cljs
@@ -1,48 +1,104 @@
 (ns kti-web.components.review-editor
   (:require
+   [reagent.core :as r]
+   [cljs.core.async :refer [<! >!]]
    [kti-web.models.reviews :as reviews-models]
-   [kti-web.utils :as utils]
+   [kti-web.utils :as utils :refer [join-vecs]]
+   [kti-web.utilsc :refer-macros [go-with-done-chan]]
    [kti-web.components.utils :as components-utils :refer [input]]))
 
-(def inputs
-  (-> reviews-models/inputs
-      (assoc :id [input {:disabled true :text "Id"}])))
+(def inputs (assoc reviews-models/inputs :id [input {:disabled true :text "Id"}]))
 
-;; !!!! TODO -> Disable all during loading
 (defn review-editor-form
   "A form to edit reviews"
-  [{:keys [edited-review on-edited-review-change on-edited-article-submit]}]
-  (letfn [(on-change [k v] (on-edited-review-change (assoc edited-review k v)))
-          (make-input [k]
-            (let [[comp props] (get inputs k)]
-              [comp (assoc props
-                           :key k
-                           :value (get edited-review k)
-                           :on-change #(on-change k %))]))]
-    (into
-     [:form {:on-submit (utils/call-prevent-default #(on-edited-article-submit))}]
-     (doall (map make-input [:id :id-article :feedback-text :status])))))
+  [{:keys [edited-review on-edited-review-change on-edited-review-submit loading?]}]
+  (letfn [(on-change [k v] (on-edited-review-change (assoc edited-review k v)))]
+    (join-vecs
+     [:form {:on-submit (utils/call-prevent-default #(on-edited-review-submit))}]
+     (for [k [:id :id-article :feedback-text :status]
+           :let [[comp props] (get inputs k)
+                 value (get edited-review k)
+                 new-props {:key k :value value :on-change #(on-change k %)}]]
+       [comp (merge props new-props (when loading? {:disabled true}))])
+     [[components-utils/submit-button]])))
 
 (defn review-selector
   "Selector for a review"
   [{:keys [on-review-selection-submit selected-review-id
            on-selected-review-id-change selection-status]}]
   [:form {:on-submit (utils/call-prevent-default #(on-review-selection-submit))}
-   [input {:text "Id"
+   [input {:text "Review Id: "
            :type "number"
            :value selected-review-id
-           :on-change on-selected-review-id-change}]
+           :on-change on-selected-review-id-change
+           :width 120}]
+   [components-utils/submit-button]
    [components-utils/errors-displayer {:status selection-status}]])
+
+(defn reduce-on-selection-submit
+  "Handles when an user submits a selection"
+  [state {:keys [error? data] :as response}]
+  (assoc state
+         :loading? false
+         :selection-status (if error? {:errors data} {:success-msg "SUCCESS"})
+         :edited-review (when-not error? (-> data
+                                             ;; !!!! TODO This should happen at req level
+                                             ;; https://trello.com/c/oSHUa1xU
+                                             reviews-models/server-resp->review
+                                             reviews-models/review->raw-spec))))
+
+(defn reduce-on-edited-review-submit
+  "Handles when an user submits an edited review"
+  [{:keys [edited-review] :as state} {:keys [error? data] :as response}]
+  (assoc state
+         :loading? false
+         :status (if error? {:errors data} {:success-msg "SUCCESS"})
+         :edited-review (if error?
+                          edited-review
+                          (-> data
+                              ;; !!!! TODO This should happen at req level
+                              ;; https://trello.com/c/oSHUa1xU
+                              reviews-models/server-resp->review
+                              reviews-models/review->raw-spec))))
 
 (defn review-editor--inner
   "Pure component for editing review"
   [props]
   [:div
+   [:h3 "Edit Review"]
    [review-selector props]
    (when (:edited-review props) [review-editor-form props])
    [components-utils/errors-displayer props]
    [components-utils/success-message-displayer props]])
 
 (defn review-editor
-  [specs]
-  [:span "NOT IMPLEMENTED"])
+  [{:keys [get-review! put-review!]}]
+  (let [state (r/atom {:status {}
+                       :selection-status {}
+                       :selected-review-id nil
+                       :edited-review nil
+                       :loading? false})
+        handle-review-selection-submit
+        (fn []
+          (swap! state assoc :loading? true :edited-review nil :selection-status {})
+          (let [get-chan (get-review! (:selected-review-id @state))]
+            (go-with-done-chan
+             (swap! state reduce-on-selection-submit (<! get-chan)))))
+        handle-edited-review-submit
+        (fn []
+          (swap! state assoc :loading? true :status {})
+          (let [{:keys [selected-review-id edited-review]} @state
+                put-chan (put-review!
+                          selected-review-id
+                          (-> edited-review
+                              (dissoc :id)
+                              reviews-models/raw-spec->spec))]
+            (go-with-done-chan
+             (swap! state reduce-on-edited-review-submit (<! put-chan)))))]
+    (fn []
+      [review-editor--inner
+       (assoc @state
+              :on-selected-review-id-change #(swap! state assoc :selected-review-id %)
+              :on-review-selection-submit handle-review-selection-submit
+              :on-edited-review-change #(swap! state assoc :edited-review %)
+              :on-edited-review-submit handle-edited-review-submit)])))

--- a/src/cljs/kti_web/core.cljs
+++ b/src/cljs/kti_web/core.cljs
@@ -26,7 +26,9 @@
               post-captured-reference!
               put-article!
               put-captured-reference!
-              post-review!]]
+              post-review!
+              put-review!
+              get-review!]]
             [kti-web.state :refer [host init-state token]]
             [kti-web.utils :as utils :refer [call-prevent-default call-with-val]]
             [reagent.core :as r]
@@ -81,7 +83,7 @@
      [:div
       [:h2 "Reviews"]
       [review-creator {:post-review! post-review!}]
-      [review-editor {}]
+      [review-editor {:get-review! get-review! :put-review! put-review!}]
       [review-deletor {}]]]))
 
 (defn host-input-inner [{:keys [value on-change]}]

--- a/src/cljs/kti_web/http.cljs
+++ b/src/cljs/kti_web/http.cljs
@@ -101,8 +101,20 @@
    {:http-fn http/delete
     :url (api-url (str "articles/" id))}))
 
+;; !!!! TODO -> This guy should parse the response
+(defn get-review! [id]
+  (run-req!
+   {:http-fn http/get
+    :url (api-url (str "reviews/" id))}))
+
 (defn post-review! [spec]
   (run-req!
    {:http-fn http/post
     :url (api-url "reviews")
+    :json-params spec}))
+
+(defn put-review! [id spec]
+  (run-req!
+   {:http-fn http/put
+    :url (api-url (str "reviews/" id))
     :json-params spec}))

--- a/src/cljs/kti_web/models/reviews.cljs
+++ b/src/cljs/kti_web/models/reviews.cljs
@@ -22,6 +22,11 @@
       (= raw v)  key
       :else      (recur raw-rest key-rest))))
 
+(defn status->raw-status
+  "Converts a status into raw-status"
+  [x]
+  (first (filter #(= (raw-status->status %) x) raw-status)))
+
 (defn raw-spec->spec
   "Converts from review raw-spec into a spec"
   [raw-spec]
@@ -30,3 +35,16 @@
                                  :id-article (js/parseInt v)
                                  v)])
                 raw-spec)))
+
+(defn review->raw-spec
+  "Converts from a review into a raw spec"
+  [{:keys [status id-article id] :as review}]
+  (-> review
+      (update :id str)
+      (update :id-article str)
+      (update :status status->raw-status)))
+
+(defn server-resp->review
+  "Deserializes the response from the server into a review."
+  [{:keys [status] :as review}]
+  (update review :status raw-status->status))

--- a/src/cljs/kti_web/utils.cljs
+++ b/src/cljs/kti_web/utils.cljs
@@ -7,3 +7,4 @@
 (defn call-prevent-default [f] #(do (.preventDefault %) (f %)))
 (defn js-alert [x] (js/alert x))
 (defn to-str [x] (with-out-str (cljs.pprint/pprint x)))
+(defn join-vecs [v & vs] (if (nil? vs) v (let [[h & t] vs] (recur (into v h) t))))

--- a/test/cljs/kti_web/components/review_editor_test.cljs
+++ b/test/cljs/kti_web/components/review_editor_test.cljs
@@ -2,12 +2,12 @@
   (:require
    [cljs.test :refer-macros [is are deftest testing use-fixtures async]]
    [cljs.core.async :refer [chan <! >! put! go] :as async]
+   [kti-web.models.reviews :as reviews-models]
    [kti-web.components.review-editor :as rc]
    [kti-web.components.utils :as components-utils]
    [kti-web.models.reviews :as models-reviews]
    [kti-web.test-utils :as utils]
    [kti-web.test-factories :as factories]))
-
 
 (deftest test-review-editor-form
   (let [mount rc/review-editor-form
@@ -17,7 +17,7 @@
         get-status-input-props #(get-in % [5 1])]
     (testing "On submit"
       (let [[args fun] (utils/args-saver)
-            comp (mount {:on-edited-article-submit fun})]
+            comp (mount {:on-edited-review-submit fun})]
         ((get-in comp [1 :on-submit]) (utils/prevent-default-event))
         (is (= @args [[]]))))
     (testing "Id input value"
@@ -56,7 +56,10 @@
       (let [[args fun] (utils/args-saver)
             comp (mount {:edited-review {::a ::b} :on-edited-review-change fun})]
         ((-> comp get-status-input-props :on-change) :completed)
-        (is (= @args [[{::a ::b :status :completed}]]))))))
+        (is (= @args [[{::a ::b :status :completed}]]))))
+    (testing "Inputs are disabled if loading?"
+      (are [i] (true? (-> {:loading? true} mount (get-in [i 1]) :disabled))
+        2 3 4 5))))
 
 (deftest test-review-selector
   (let [mount rc/review-selector]
@@ -73,15 +76,15 @@
         ((get-in comp [2 1 :on-change]) 9)
         (is (= @args [[9]]))))
     (testing "Displays error message based on selection-status"
-      (is (= (-> {:selection-status {::a ::b}} mount (get 3))
+      (is (= (-> {:selection-status {::a ::b}} mount (get 4))
              [components-utils/errors-displayer {:status {::a ::b}}])))))
 
 (deftest test-review-editor--inner
   (let [mount rc/review-editor--inner
-        get-review-selector #(get % 1)
-        get-form #(get % 2)
-        get-err-comp #(get % 3)
-        get-success-msg-comp #(get % 4)]
+        get-review-selector #(get % 2)
+        get-form #(get % 3)
+        get-err-comp #(get % 4)
+        get-success-msg-comp #(get % 5)]
     (testing "Mounts form with props"
       (is (= (-> {:edited-review {::a ::b}}
                  mount
@@ -98,3 +101,144 @@
     (testing "Renders review-selector"
       (is (= (-> {::a ::b} mount get-review-selector)
              [rc/review-selector {::a ::b}])))))
+
+(deftest test-reduce-on-selection-submit
+  (testing "Set's status on success"
+    (let [response {:data factories/review-server-resp}]
+      (is (= (rc/reduce-on-selection-submit {} response)
+             {:loading? false
+              :selection-status {:success-msg "SUCCESS"}
+              :edited-review (reviews-models/review->raw-spec factories/review)}))))
+  (testing "Set's error on failure"
+    (let [response {:error? true :data {::a ::b}}]
+      (is (= (rc/reduce-on-selection-submit {} response)
+             {:loading? false
+              :selection-status {:errors {::a ::b}}
+              :edited-review nil})))))
+
+(deftest test-reduce-on-edited-review-submit
+  (testing "Set's status on success"
+    (let [response {:data factories/review-server-resp}]
+      (is (= (rc/reduce-on-edited-review-submit {} response)
+             {:loading? false
+              :status {:success-msg "SUCCESS"}
+              :edited-review (-> factories/review-server-resp
+                                 reviews-models/server-resp->review
+                                 reviews-models/review->raw-spec)}))))
+  (testing "Set's status on error"
+    (let [response {:error? true :data {::a ::b}}]
+      (is (= (rc/reduce-on-edited-review-submit {:edited-review ::a} response)
+             {:loading? false
+              :status {:errors {::a ::b}}
+              :edited-review ::a})))))
+
+(deftest test-review-editor
+  (let [mount rc/review-editor]
+    (testing "Renders inner"
+      (is (= (-> {} mount (apply [{}]) (get-in [0]))
+             rc/review-editor--inner)))
+    (testing "Inner initial inputs"
+      (let [comp ((mount {:put-review! ::put}) {})]
+        (are [k v] (= (get-in comp [1 k]) v)
+          :selection-status {}
+          :status {}
+          :edited-review nil
+          :select-review-id nil
+          :loading? false)))))
+
+(deftest test-review-editor--on-selection-okay
+  (let [get-chan (chan)
+        [args fun] (utils/args-saver)
+        comp1 (rc/review-editor {:get-review! #(do (fun %&) get-chan)})]
+    ;; User selects an id
+    ((get-in (comp1) [1 :on-selected-review-id-change]) 99)
+    ;; And submits the selection
+    (let [resp-chan ((get-in (comp1) [1 :on-review-selection-submit]))]
+      (async done
+             (go
+               ;; The app is loading
+               (is (true? (get-in (comp1) [1 :loading?])))
+               ;; The answer is given
+               (>! get-chan {:data factories/review-server-resp})
+               (is (= :done (<! resp-chan)))
+               ;; No longer loading
+               (is (false? (get-in (comp1) [1 :loading?])))
+               ;; and we have the edited-review set
+               (is (= (get-in (comp1) [1 :edited-review])
+                      (reviews-models/review->raw-spec factories/review)))
+               (done))))))
+
+(deftest test-review-editor--on-selection-error
+  (let [get-chan (chan)
+        [args fun] (utils/args-saver)
+        comp1 (rc/review-editor {:get-review! #(do (fun %&) get-chan)})]
+    (let [resp-chan ((get-in (comp1) [1 :on-review-selection-submit]))]
+      (async done
+             (go
+               ;; An errored response is given
+               (>! get-chan {:error? true :data {::a ::b}})
+               (is (= :done (<! resp-chan)))
+               ;; and is set on the props
+               (is (= (get-in (comp1) [1 :selection-status]) {:errors {::a ::b}}))
+               (done))))))
+
+(deftest test-review-editor--on-edited-article-submit-okay
+  (let [get-chan (async/to-chan [{:data factories/review-server-resp}])
+        put-chan (chan)
+        [args fun] (utils/args-saver)
+        comp1 (rc/review-editor {:get-review! (constantly get-chan)
+                                 :put-review! #(do (apply fun %&) put-chan)})
+        updated-review-raw-spec {:id-article 99
+                                 :status "completed"
+                                 :feedback-text "It sucks!"}]
+    (async
+     done
+     (go
+       ;; User selects an id
+       ((get-in (comp1) [1 :on-selected-review-id-change])
+        (:id factories/review-server-resp))
+       ;; And submits the selection
+       (let [selection-resp-chan ((get-in (comp1) [1 :on-review-selection-submit]))]
+         (is (= :done (<! selection-resp-chan)))
+         ;; It edits the review
+         ((get-in (comp1) [1 :on-edited-review-change]) updated-review-raw-spec)
+         ;; And submits
+         (let [edit-resp-chan ((get-in (comp1) [1 :on-edited-review-submit]))]
+           ;; It is loading
+           (is (true? (get-in (comp1) [1 :loading?])))
+           ;; It receives the response
+           (>! put-chan {:data factories/review-server-resp})
+           (is (= :done (<! edit-resp-chan)))
+           ;; And is no longer loading
+           (is (false? (get-in (comp1) [1 :loading?])))
+           ;; And put was called correctly
+           (is (= @args
+                  [[(:id factories/review-server-resp)
+                    (reviews-models/raw-spec->spec updated-review-raw-spec)]]))
+           ;; And the response is set as edited response
+           (is (= (get-in (comp1) [1 :edited-review])
+                  (-> factories/review-server-resp
+                      reviews-models/server-resp->review
+                      reviews-models/review->raw-spec)))
+           ;; And status is success
+           (is (= (get-in (comp1) [1 :status]) {:success-msg "SUCCESS"}))
+           (done)))))))
+
+(deftest test-review-editor--on-edited-article-submit-error
+  (let [get-chan (async/to-chan [{:data factories/review-server-resp}])
+        put-chan (async/to-chan [{:error? true :data {::a ::b}}])
+        [args fun] (utils/args-saver)
+        comp1 (rc/review-editor {:get-review! (constantly get-chan)
+                                 :put-review! (constantly put-chan)})]
+    (async
+     done
+     (go
+       ;; User submits the editting
+       (is (= :done (<! ((get-in (comp1) [1 :on-edited-review-submit])))))
+       ;; And we are not loading anymore
+       (is (false? (get-in (comp1) [1 :loading?])))
+       ;; And the error is set
+       (is (= (get-in (comp1) [1 :status]) {:errors {::a ::b}}))
+       (done)))))
+      
+      

--- a/test/cljs/kti_web/doo_runner.cljs
+++ b/test/cljs/kti_web/doo_runner.cljs
@@ -13,7 +13,8 @@
             [kti-web.components.review-editor-test]
             [kti-web.components.review-deletor-test]
             [kti-web.components.review-creator-test]
-            [kti-web.models.reviews-test]))
+            [kti-web.models.reviews-test]
+            [kti-web.utils-test]))
 
 (doo-tests 'kti-web.core-test
            'kti-web.http-test
@@ -28,4 +29,5 @@
            'kti-web.components.review-editor-test
            'kti-web.components.review-deletor-test
            'kti-web.components.review-creator-test
-           'kti-web.models.reviews-test)
+           'kti-web.models.reviews-test
+           'kti-web.utils-test)

--- a/test/cljs/kti_web/test_factories.cljs
+++ b/test/cljs/kti_web/test_factories.cljs
@@ -62,6 +62,12 @@
   {:id 823
    :id-article 121
    :feedback-text "It rocks!"
+   :status :completed})
+
+(def review-server-resp
+  {:id 823
+   :id-article 121
+   :feedback-text "It rocks!"
    :status "completed"})
 
 (defn ok-response

--- a/test/cljs/kti_web/utils_test.cljs
+++ b/test/cljs/kti_web/utils_test.cljs
@@ -1,0 +1,11 @@
+(ns kti-web.utils-test
+  (:require [kti-web.utils :as rc]
+            [cljs.test :as t :include-macros true]))
+
+
+(t/deftest test-join-vecs
+  (t/is (= (rc/join-vecs []) []))
+  (t/is (= (rc/join-vecs [:a :b]) [:a :b]))
+  (t/is (= (rc/join-vecs [:a :b] []) [:a :b]))
+  (t/is (= (rc/join-vecs [:a :b] [:c :d]) [:a :b :c :d]))
+  (t/is (= (rc/join-vecs [:a :b] [:c :d] [:e :f]) [:a :b :c :d :e :f])))


### PR DESCRIPTION
- NEW Adds get-review! and put-review! http calls
- NEW Adds conversion `server-resp->review`
- OPT Adds join-vecs in utils.cljs.
- FIX Renames `on-edited-article-submit` -> `on-edited-review-submit`