### PR TITLE
NEW Adds pagination to captured reference table

### DIFF
--- a/resources/public/css/site.css
+++ b/resources/public/css/site.css
@@ -45,6 +45,7 @@ a:hover {
 }
 
 .modal-wrapper-div {
+    z-index: 99999;
     width: 100%;
     height: 100%;
     position: fixed;

--- a/src/cljs/kti_web/core.cljs
+++ b/src/cljs/kti_web/core.cljs
@@ -26,6 +26,7 @@
               get-article!
               get-captured-reference!
               get-captured-references!
+              get-paginated-captured-references!
               post-article!
               post-captured-reference!
               put-article!
@@ -106,7 +107,7 @@
       [capture-form {:post! post-captured-reference!}]
       [captured-refs-table
        (merge
-        {:get! get-captured-references!}
+        {:get-paginated-captured-references! get-paginated-captured-references!}
         (select-keys main-captured-reference-deletor-modal-handlers
                      [:on-modal-display-for-deletion]))]
       [edit-captured-ref-comp {:hput! put-captured-reference!

--- a/src/cljs/kti_web/pagination.cljs
+++ b/src/cljs/kti_web/pagination.cljs
@@ -1,0 +1,7 @@
+(ns kti-web.pagination)
+
+(defn is-paginated?
+  "Returns true if `r` is a paginated response, according to back end specs."
+  [r]
+  (and (every? #(% r) [:page :page-size :total-items :items])
+       (sequential? (:items r))))

--- a/test/cljs/kti_web/components/captured_reference_table_test.cljs
+++ b/test/cljs/kti_web/components/captured_reference_table_test.cljs
@@ -39,67 +39,152 @@
         (is (= (accessor ::row) ::row))
         (is (= (cell-fn  ::row) ::action-buttons))))))
 
+(deftest test-props->rtable-props
+  (testing "Base"
+    (with-redefs [rc/make-columns (constantly ::make-columns-response)
+                  rc/refs->data   (constantly ::refs->data-response)
+                  rc/handler-wrapper-avoid-useless-fetching
+                  (constantly ::wrapper-response)]
+      (let [refs [{:created-at 2} {:created-at 1}]
+            page 2
+            pageSize 10
+            pages 4
+            fn-refresh! (constantly ::fn-refresh-response)
+            props {:refs refs
+                   :fn-refresh! fn-refresh!
+                   :table-state {:page page :pageSize pageSize :pages pages}}]
+        (is (= (rc/props->rtable-props props)
+               {:data ::refs->data-response
+                :page page
+                :pageSize pageSize
+                :on-fetch-data ::wrapper-response
+                :columns ::make-columns-response
+                :manual true
+                :pages pages}))))))
+
 (deftest test-captured-refs-table-inner
   (let [mount rc/captured-refs-table-inner
         get-refresh-button #(get % 2)
         get-table #(get % 3)]
     (testing "Calls fn-refresh!"
       (let [[args fun] (utils/args-saver)
-            comp (mount {:fn-refresh! fun})]
+            table-state {:page 1 :pageSize 2}
+            comp (mount {:fn-refresh! fun :table-state table-state})]
         ((-> comp get-refresh-button (get-in [1 :on-click])) ::foo)
         (is (= @args [[]]))))
     (testing "Mounts table..."
-      (let [c (mount {})
-            table (get-table c)]
-        (is (= (get table 0) rtable))
-        (is (not (nil? (get-in table [1 :columns]))))
-        (is (not (nil? (get-in table [1 :data]))))))))
+      (with-redefs [rc/props->rtable-props (constantly ::rtable-props)]
+        (let [c (mount {})
+              table (get-table c)]
+          (is (= (get table 0) rtable))
+          (is (= (get table 1) ::rtable-props)))))))
 
-(deftest test-refresh
-  (testing "r-before"
-    (let [r-before (:r-before rc/refresh)]
-      (is (= (r-before {::a ::b} {}) {::a ::b :loading? true :refs nil :status {}}))))
-  (testing "r-after"
-    (let [r-after (:r-after rc/refresh)]
-      (is (= (r-after {::a ::b} {} {:error? true :data ::c})
-             {::a ::b :loading? false :status {:errors ::c} :refs nil}))
-      (is (= (r-after {::a ::b} {} {:data ::c})
-             {::a ::b :loading? false :status {:success-msg "Success!"} :refs ::c})))))
+(deftest test-refresh-paginated
+  (let [[r-before action r-after] rc/refresh-paginated-vec]
+    (testing "r-before"
+      (let [state {}
+            event {:page 1 :pageSize 2}]
+        (is (= (r-before state nil event)
+               {:table-state {:loading true :page 1 :pageSize 2}
+                :refs nil
+                :status nil}))))
+    (testing "action"
+      (let [get-paginated-captured-references! identity
+            state-page 2
+            state-page-size 100
+            state {:table-state {:page state-page :pageSize state-page-size}}
+            event-page 3
+            event-page-size 200
+            event {:page event-page :pageSize event-page-size}
+            extra-args {:get-paginated-captured-references!
+                        get-paginated-captured-references!}]
+        (is (= (action state extra-args event)
+               {:page (inc event-page) :page-size event-page-size}))))
+    (testing "r-after"
+      (is (= (r-after {::a ::b} {} nil {:error? true :data ::c})
+             {::a ::b
+              :table-state {:loading false}
+              :status {:errors ::c}}))
+      (let [resp-data {:page 1 :page-size 2 :total-items 3 :items [4 5]}]
+        (is (= (r-after {} {} nil {:error? false :data resp-data})
+               {:refs [4 5]
+                :table-state {:pages 2 :loading false}}))))))
+
+(deftest test-handler-wrapper-avoid-useless-fetching
+  (testing "page/pageSize changes"
+    (let [props {:table-state {:page 1 :pageSize 2}}
+          event {:page 2 :pageSize 3}
+          handler (constantly ::handler-resp)
+          wrapped-handler (rc/handler-wrapper-avoid-useless-fetching handler props)]
+      (is (= (wrapped-handler event) ::handler-resp))))
+  (testing "no change"
+    (let [event {:page 1 :pageSize 2}
+          props {:table-state event}
+          handler (constantly ::handler-resp)
+          wrapped-handler (rc/handler-wrapper-avoid-useless-fetching handler props)]
+      (is (= (wrapped-handler event) nil)))))
 
 (deftest test-captured-refs-table--integration
   (let [mount rc/captured-refs-table
         get-chan (async/timeout 2000)
-        done-chan (async/timeout 2000)]
-    (let [comp1 (mount {:get! (constantly get-chan) :c-done done-chan})]
+        page 2
+        page-size 20
+        total-items 100
+        items [factories/captured-ref]
+        response {:data {:page page
+                         :page-size page-size
+                         :total-items total-items
+                         :items items}}]
+    ;; Ensure we are at a clean state
+    (reset! rc/state rc/initial-state)
+    (let [comp1 (mount {:get-paginated-captured-references! (constantly get-chan)})]
       ;; First state must be while loading
+      (let [comp (comp1)
+            props (get comp 1)
+            {:keys [refs status]} props
+            table-loading (get-in props [:table-state :loading])]
+        (is (= true table-loading))
+        (is (= nil refs))
+        (is (= nil status)))
       (is (= (get (comp1) 0) rc/captured-refs-table-inner))
-      (is (= (-> (comp1) (get 1) (dissoc :fn-refresh! :on-modal-display-for-deletion))
-             {:loading? true :refs nil :status {}}))
       (async
        done
        (go
-         ;; Then the response arrives and finished
-         (>! get-chan {:data [factories/captured-ref]})
-         (is (= (<! done-chan) 1))
+         ;; Then the response arrives and finishes
+         (>! get-chan response)
+         (<! (async/timeout 100))
          ;; And the new state is set
-         (is (= (-> (comp1) (get 1) (dissoc :fn-refresh! :on-modal-display-for-deletion))
-                {:loading? false
-                 :status {:success-msg "Success!"}
-                 :refs [factories/captured-ref]}))
+         (let [comp (comp1)
+               props (get comp 1)
+               {:keys [refs status]} props
+               table-loading (get-in props [:table-state :loading])]
+           (is (= false table-loading))
+           (is (= [factories/captured-ref] refs))
+           (is (= nil status)))
          ;; The user refreshes
-         ((get-in (comp1) [1 :fn-refresh!]))
-         ;; We are loading again
-         (is (= (-> (comp1) (get 1) (dissoc :fn-refresh! :on-modal-display-for-deletion))
-                {:loading? true :status {} :refs nil}))
-         ;; An error is returned
-         (>! get-chan {:error? true :data {::some "error"}})
-         ;; It ends
-         (is (= (<! done-chan) 1))
+         (let [done-chan ((get-in (comp1) [1 :fn-refresh!])
+                          {:page 1 :pageSize 9})]
+           
+           ;; We are loading again
+           (let [comp (comp1)
+                 props (get comp 1)
+                 {:keys [refs status]} props
+                 table-loading (get-in props [:table-state :loading])]
+             (is (= true table-loading))
+             (is (= nil refs))
+             (is (= nil status)))
+           ;; An error is returned
+           (>! get-chan {:error? true :data {::some "error"}})
+           ;; It ends
+           (is (= (<! done-chan) :done)))
          ;; And we see the error there
-         (is (= (-> (comp1) (get 1) (dissoc :fn-refresh! :on-modal-display-for-deletion))
-                {:loading? false
-                 :status {:errors {::some "error"}}
-                 :refs nil}))
+         (let [comp (comp1)
+               props (get comp 1)
+               {:keys [refs status]} props
+               table-loading (get-in props [:table-state :loading])]
+           (is (= false table-loading))
+           (is (= nil refs))
+           (is (= {:errors {::some "error"}} status)))
          (done))))))
 
 ;; (deftest test-captured-refs-table--integration--delete-modal

--- a/test/cljs/kti_web/components/rtable_test.cljs
+++ b/test/cljs/kti_web/components/rtable_test.cljs
@@ -3,6 +3,14 @@
             [cljs.test :refer-macros [is are deftest testing use-fixtures async]]
             [reagent.core :as r]))
 
+(deftest test-wrap-on-fetch-data
+  (let [instance ::instance
+        instance-state (clj->js {:page 1 :pageSize 10})
+        f #(vec %&)
+        wrapped (sut/wrap-on-fetch-data f)]
+    (is (= (wrapped instance-state instance)
+           [{:page 1 :pageSize 10}]))))
+
 (deftest test-rtable
   (testing "Returns adapted react class with parsed props"
     (with-redefs [r/adapt-react-class (constantly ::adapted-class)

--- a/test/cljs/kti_web/core_test.cljs
+++ b/test/cljs/kti_web/core_test.cljs
@@ -39,11 +39,6 @@
       (do (println "Not found: " res)
           false))))
 
-(deftest test-home
-  (with-mounted-component (rc/home-page)
-    (fn [c div]
-      (is (found-in #"Welcome to" div)))))
-
 (deftest test-capture-input
   (testing "Calls callback on change"
     (let [[callback-args callback] (args-saver)

--- a/test/cljs/kti_web/pagination_test.cljs
+++ b/test/cljs/kti_web/pagination_test.cljs
@@ -1,0 +1,15 @@
+(ns kti-web.pagination-test
+  (:require [kti-web.pagination :as sut]
+            [cljs.test :refer-macros [is are deftest testing use-fixtures async]]))
+
+(deftest test-is-paginated?
+  (are [x] (is (sut/is-paginated? x))
+    {:page 1 :page-size 2 :total-items 20 :items [1 2 3]}
+    {:page 1 :page-size 2 :total-items 20 :items []}
+    {:page 1 :page-size 2 :total-items 20 :items '()})
+  (are [x] (is (not (sut/is-paginated? x)))
+    {:page-size 2 :total-items 20 :items nil}
+    {:page 1 :total-items 20 :items []}
+    {:page 1 :page-size 2 :items '()}
+    {:page 1 :page-size 2 :total-items 20}
+    {:page 1 :page-size 2 :total-items 20 :items 2}))


### PR DESCRIPTION
- FIX z-index on `.model-wrapper-div` to ensure modal is rendered on
  top.
- FIX uses `rtable` `:loading` props instead of custom `:loading?`
  prop.
- OPT more helper functions for rendering captured refs table.
- NEW Handlers pagination on state for captured refs table.
- NEW Adds `wrap-on-fetch-data` for `onFetchData` options for
  ReactTable.
- NEW Adds `query-params` to http `prepare-request-opts` and
  `run-req!`.
- NEW Adds `get-paginated-captured-references`.