### PR TITLE
FIX Fixes cljs bug on externs for foreign-libs

### DIFF
--- a/dev.cljs.edn
+++ b/dev.cljs.edn
@@ -1,9 +1,12 @@
 ^{:watch-dirs ["src/cljc" "src/cljs" "env/dev/cljs" "test/cljs"]}
 {:main "kti-web.dev"
  :npm-deps false
- :foreign-libs [{:file "dist/index_bundle.js"
-                 :provides ["react" "react-dom" "react-select" "react-table"]
+ :foreign-libs [{:file "dist/main.js"
+                 :provides ["react" "react-dom" "react-select"]
                  :global-exports {react React
                                   react-dom ReactDOM
-                                  react-select Select
-                                  react-table ReactTable}}]}
+                                  react-select Select}}
+                {:file "dist/react_table.js"
+                 :requires ["react" "react-dom"]
+                 :provides ["react-table"]
+                 :global-exports {react-table ReactTable}}]}

--- a/project.clj
+++ b/project.clj
@@ -53,12 +53,15 @@
               :infer-externs true
               :pretty-print  false
               :npm-deps      false
-              :foreign-libs [{:file "dist/index_bundle.js"
-                              :provides ["react" "react-dom" "react-select" "react-table"]
+              :foreign-libs [{:file "dist/main.js"
+                              :provides ["react" "react-dom" "react-select"]
                               :global-exports {react React
                                                react-dom ReactDOM
-                                               react-select Select
-                                               react-table ReactTable}}]}}
+                                               react-select Select}}
+                             {:file "dist/react_table.js"
+                              :requires ["react" "react-dom"]
+                              :provides ["react-table"]
+                              :global-exports {react-table ReactTable}}]}}
             :test
             {:source-paths ["src/cljs" "src/cljc" "test/cljs"]
              :compiler {:main kti-web.doo-runner
@@ -68,12 +71,15 @@
                         :optimizations :whitespace
                         :pretty-print true
                         :npm-deps false
-                        :foreign-libs [{:file "dist/index_bundle.js"
-                                        :provides ["react" "react-dom" "react-select" "react-table"]
+                        :foreign-libs [{:file "dist/main.js"
+                                        :provides ["react" "react-dom" "react-select"]
                                         :global-exports {react React
                                                          react-dom ReactDOM
-                                                         react-select Select
-                                                         react-table ReactTable}}]
+                                                         react-select Select}}
+                                       {:file "dist/react_table.js"
+                                        :requires ["react" "react-dom"]
+                                        :provides ["react-table"]
+                                        :global-exports {react-table ReactTable}}]
                         :infer-externs true}}}}
 
   :doo {:build "test"

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -4,9 +4,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Select from 'react-select';
-import ReactTable from 'react-table'
 
 window.React = React;
 window.ReactDOM = ReactDOM;
 window.Select = Select;
-window.ReactTable = ReactTable

--- a/src/js/react-table.js
+++ b/src/js/react-table.js
@@ -1,0 +1,2 @@
+import ReactTable from 'react-table';
+window.ReactTable = ReactTable;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,9 @@
 module.exports = {
-    entry: './src/js/index.js',
+    entry: {
+        main: './src/js/index.js',
+        react_table: './src/js/react-table.js'
+    },
     output: {
-        filename: 'index_bundle.js'
+        filename: '[name].js'
     }
 }


### PR DESCRIPTION
For some reason bundling `react-table` together leads to
both ReactTable and Select to be undefined.