### PR TITLE
NEW Adds button from captured reference table to article id

### DIFF
--- a/src/cljs/kti_web/navigation_subscription.cljs
+++ b/src/cljs/kti_web/navigation_subscription.cljs
@@ -1,0 +1,23 @@
+(ns kti-web.navigation-subscription
+  (:require
+   [cljs.core.async :as async :include-macros true]))
+
+(defn- navigated-route->route-name
+  [{{name :name} :data}]
+  {:pre [(keyword? name)]}
+  name)
+
+(defn create-page-navigation-subscription
+  "Creates a subscription for page navigation."
+  []
+  (let [chan (async/chan)
+        pub  (async/pub chan navigated-route->route-name)
+        subscribed (atom #{})]
+    {:subscribe!
+     (fn [topic chan]
+       (async/sub pub topic chan))
+
+     :publish!
+     (fn [route]
+       (async/go (async/>! chan route)))}))
+

--- a/test/cljs/kti_web/components/article_viewer_test.cljs
+++ b/test/cljs/kti_web/components/article_viewer_test.cljs
@@ -24,6 +24,19 @@
         (handler)
         (is (= @args [[nil ::state ::props rc/view-article-id-selection]]))))))
 
+(deftest test-handle-on-show-article
+  (let [[args saver] (utils/args-saver)]
+    ;; We just test the two other handlers are called
+    (with-redefs [rc/handle-on-selected-view-article-id-change
+                  (fn [s p] (fn [e] (saver :change s p e)))
+                  rc/handle-on-selected-view-article-id-submit
+                  (fn [s p] (fn [e] (saver :submit s p e)))]
+      (let [handler (rc/handle-on-show-article ::state ::props)]
+        (handler ::event)
+        (is (= @args
+               [[:change ::state ::props ::event]
+                [:submit ::state ::props nil]]))))))
+
 (deftest test-article-viewer-inner
   (let [mount rc/article-viewer-inner]
 

--- a/test/cljs/kti_web/components/captured_reference_table_test.cljs
+++ b/test/cljs/kti_web/components/captured_reference_table_test.cljs
@@ -22,6 +22,33 @@
     (is (= (handler) {:filters [rc/empty-filter]}))
     (is (= @state {:filters [rc/empty-filter]}))))
 
+(deftest test-handle-show-article
+  ;; Simple call the props handler
+  (let [on-show-article #(apply vector :on-show-article %&)
+        props {:on-show-article on-show-article}
+        handler (rc/handle-show-article {} props)]
+    (is (= [:on-show-article 99]
+           (handler 99)))))
+
+(deftest test-article-id-action-button
+
+  (testing "With article id"
+    (let [[args saver] (utils/args-saver)
+          article-id 99
+          props {:article-id article-id :on-show-article saver}
+          comp (rc/article-id-action-button props)]
+      (is (= :button (get comp 0)))
+      (is (= article-id (get comp 2)))
+      (let [on-click (get-in comp [1 :on-click])]
+        (is (fn? on-click))
+        (on-click)
+        (is (= [[article-id]] @args)))))
+
+  (testing "No article id"
+    (is (nil? (rc/article-id-action-button {})))
+    (is (nil? (rc/article-id-action-button {:article-id nil})))
+    (is (nil? (rc/article-id-action-button {:article-id ""})))))
+
 (deftest test-delete-captured-ref-action-button
   (let [[on-modal-display-for-deletion-args on-modal-display-for-deletion-fun]
         (utils/args-saver)

--- a/test/cljs/kti_web/core_test.cljs
+++ b/test/cljs/kti_web/core_test.cljs
@@ -32,6 +32,13 @@
         (reagent/flush)
         (.removeChild (.-body js/document) div)))))
 
+(deftest test-navigated-page->show-article-event
+  (let [navigated-page->show-article-event #'rc/navigated-page->show-article-event]
+    (is (nil? (navigated-page->show-article-event {})))
+    (is (nil? (navigated-page->show-article-event {:query-params {}})))
+    (is (= [:on-show-article 9]
+           (navigated-page->show-article-event {:query-params {:id 9}})))))
+
 (defn found-in [re div]
   (let [res (.-innerHTML div)]
     (if (re-find re res)

--- a/test/cljs/kti_web/navigation_subscription_test.cljs
+++ b/test/cljs/kti_web/navigation_subscription_test.cljs
@@ -1,0 +1,30 @@
+(ns kti-web.navigation-subscription-test
+  (:require [kti-web.navigation-subscription :as sut]
+            [cljs.core.async
+             :refer [<! >!]
+             :as async
+             :include-macros true]
+            [cljs.test :refer-macros [is are deftest testing use-fixtures async]]))
+
+(deftest test-navigated-route->route-name
+  (let [navigated-route->route-name #'sut/navigated-route->route-name]
+    (is (= :index
+           (navigated-route->route-name {:data {:name :index}})))))
+
+(deftest test-create-page-navigation-subscription
+  (let [subscription (sut/create-page-navigation-subscription)
+        subscribe! (:subscribe! subscription)
+        publish! (:publish! subscription)
+        page-name ::foo
+        route {:data {:name page-name}}
+        subscribed-buff (cljs.core.async/buffer 1)
+        subscribed-chan (async/chan)
+        _ (subscribe! ::foo subscribed-chan)]
+    (async
+     done
+     (async/go
+       ;; Writes the route on the input channel
+       (publish! route)
+       ;; And receives it from the subscribed chan
+       (is (= route (<! subscribed-chan)))
+       (done)))))


### PR DESCRIPTION
- NEW Adds `on-show-article` event for `article-viewer`.
- NEW Adds `event-listeners` to `article-viewer` so `kti-web.core` can
  fire the event to display an id.
- NEW Adds button component to `captured-reference-table` that
  calls event to show an article.
- Adds navigation subscription logic so we can intercept
  `query-params` when displaying pages.